### PR TITLE
Celery fixes + Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+web: inveniomanage runserver
+cache: redis-server
+worker: celeryd -E -A invenio.celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
+workermon: flower --broker=redis://localhost:6379/1

--- a/invenio/celery/__init__.py
+++ b/invenio/celery/__init__.py
@@ -112,13 +112,10 @@ class InvenioLoader(BaseLoader):
     @with_app_context()
     def read_configuration(self):
         """ Read configuration defined in invenio.celery.config """
-        usercfg = self._import_config_module('invenio.celery.config')
-        self.configured = True
-
-        from werkzeug.datastructures import CombinedMultiDict
+        from invenio.celery.config import default_config
         from flask import current_app
-
-        return DictAttribute(CombinedMultiDict([current_app.config, usercfg]))
+        self.configured = True
+        return default_config(current_app.config)
 
     def close_database(self, **dummy_kwargs):
         if self.db:

--- a/invenio/celery/config.py
+++ b/invenio/celery/config.py
@@ -17,55 +17,77 @@
 ## along with Invenio; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
 
-#from invenio import config
-config = object()
 
-## Broker settings
-## ---------------
-BROKER_URL = getattr(config, "CFG_BROKER_URL", "amqp://guest:guest@localhost:5672//")
+def default_config(config):
+    """
+    Provide default configuration for Celery
+    """
+    ## Broker settings
+    ## ---------------
+    config.setdefault("BROKER_URL", "redis://localhost:6379/1")
 
-# Extra modules with tasks which should be loaded
-# The Invenio Celery loader automatically takes care of loading tasks defined
-# in *_tasks.py files in 'invenio' package.
-CELERY_INCLUDE = [
-    #"invenio.celery.tasks",
-    #"invenio.bibworkflow_workers.worker_celery",
-]
+    # Extra modules with tasks which should be loaded
+    # The Invenio Celery loader automatically takes care of loading tasks
+    # defined in *_tasks.py files in 'invenio' package.
+    config.setdefault("CELERY_INCLUDE", [
+        #"invenio.celery.tasks",
+        #"invenio.bibworkflow_workers.worker_celery",
+    ])
 
-## Result backend
-## --------------
-CELERY_RESULT_BACKEND = getattr(config, "CFG_CELERY_RESULT_BACKEND", "redis://localhost/0")
-CELERY_RESULT_SERIALIZER = getattr(config, "CFG_CELERY_RESULT_SERIALIZER", "msgpack")
+    ## Result backend
+    ## --------------
+    config.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+    config.setdefault("CELERY_RESULT_SERIALIZER", "msgpack")
 
-## Routing
-## -------
-# ...
+    ## Routing
+    ## -------
+    # ...
 
-## Task execution
-## --------------
-CELERY_ALWAYS_EAGER = False
-CELERY_IGNORE_RESULT = False
-CELERY_TASK_SERIALIZER = getattr(config, "CFG_CELERY_TASK_SERIALIZER", "msgpack")
+    ## Task execution
+    ## --------------
+    config.setdefault("CELERY_ALWAYS_EAGER", False)
+    config.setdefault("CELERY_IGNORE_RESULT", False)
+    config.setdefault("CELERY_TASK_SERIALIZER", "msgpack")
 
-## Worker
-## ------
-CELERYD_MAX_TASKS_PER_CHILD = getattr(config, "CFG_CELERYD_MAX_TASKS_PER_CHILD", 1000)
+    ## Worker
+    ## ------
+    config.setdefault("CELERYD_MAX_TASKS_PER_CHILD", 1000)
 
-## Error emails
-## ------------
-CELERY_SEND_TASK_ERROR_EMAILS = bool(getattr(config, "CFG_SITE_ADMIN_EMAIL_EXCEPTIONS", False))
-try:
-    ADMINS = [('', x.strip()) for x in getattr(config, "CFG_SITE_EMERGENCY_EMAIL_ADDRESSES", {})['*'].explode(",")]
-except Exception:
-    ADMINS = ()
-SERVER_EMAIL = getattr(config, "CFG_SITE_ADMIN_EMAIL", "celery@localhost")
-EMAIL_HOST = getattr(config, "CFG_MISCUTIL_SMTP_HOST", "localhost")
-EMAIL_HOST_USER = getattr(config, "CFG_MISCUTIL_SMTP_USER", "")
-EMAIL_HOST_PASSWORD = getattr(config, "CFG_MISCUTIL_SMTP_PASS", "")
-EMAIL_PORT = getattr(config, "CFG_MISCUTIL_SMTP_PORT", "25")
-EMAIL_USE_TLS = getattr(config, "CFG_MISCUTIL_SMTP_TLS", False)
+    ## Error emails
+    ## ------------
+    config.setdefault("CELERY_SEND_TASK_ERROR_EMAILS", False)
 
-## Scheduler
-## ---------
-CELERYBEAT_SCHEDULE = {
-}
+    if "CFG_SITE_EMERGENCY_EMAIL_ADDRESSES" in config:
+        try:
+            ADMINS = [
+                ('', x.strip()) for x in
+                config["CFG_SITE_EMERGENCY_EMAIL_ADDRESSES"]['*'].explode(",")
+            ]
+            config.setdefault("ADMINS", ADMINS)
+        except Exception:
+            pass
+
+    config.setdefault(
+        "SERVER_EMAIL", config.get("CFG_SITE_ADMIN_EMAIL", "celery@localhost")
+    )
+    config.setdefault(
+        "EMAIL_HOST", config.get("CFG_MISCUTIL_SMTP_HOST", "localhost")
+    )
+    config.setdefault(
+        "EMAIL_HOST_USER", config.get("CFG_MISCUTIL_SMTP_USER", "")
+    )
+    config.setdefault(
+        "EMAIL_HOST_PASSWORD", config.get("CFG_MISCUTIL_SMTP_PASS", "")
+    )
+    config.setdefault(
+        "EMAIL_PORT", config.get("CFG_MISCUTIL_SMTP_PORT", "25")
+    )
+    config.setdefault(
+        "EMAIL_USE_TLS", config.get("CFG_MISCUTIL_SMTP_TLS", False)
+    )
+
+    ## Scheduler
+    ## ---------
+    config.setdefault("CELERYBEAT_SCHEDULE", {})
+
+    return config


### PR DESCRIPTION
Celery didn't properly read the configuration and thus just used the defaults. 

Additionally I've changed default configuration to use redis as the MQ to lower the number of components you need to start.

The Procfile is an initial version that shows how to run the entire stack. It requires either Ruby Foreman (gem install foreman) or Python honcho (pip install honcho). Honcho would be preferable but it conflicts with our Jinja2 version. Example:

foreman start

will start debug server, redis-server (remember to shutdown you own redis first), celery worker, and flower celery monitoring.

There's many more possibilities, so this is just the initial version.
