### PR TITLE
legacy: websearch interface fix

### DIFF
--- a/invenio/legacy/websearch/webinterface.py
+++ b/invenio/legacy/websearch/webinterface.py
@@ -851,7 +851,7 @@ def display_collection(req, c, aas, verbose, ln, em=""):
     # deduce collection id:
     colID = get_colID(get_coll_normalised_name(c))
     if type(colID) is not int:
-        page_body = '<p>' + (_("Sorry, collection %s does not seem to exist.") % ('<strong>' + str(c) + '</strong>')) + '</p>'
+        page_body = '<p>' + (_("Sorry, collection %s does not seem to exist." % ('<strong>' + str(c) + '</strong>',))) + '</p>'
         page_body = '<p>' + (_("You may want to start browsing from %s.") % ('<a href="' + CFG_SITE_URL + '?ln=' + ln + '">' + get_coll_i18nname(CFG_SITE_NAME, ln) + '</a>')) + '</p>'
         if req.method == 'HEAD':
             raise apache.SERVER_RETURN, apache.HTTP_NOT_FOUND


### PR DESCRIPTION
- Avoids exception on bad string formatting in the warning message
  when trying to access page without collections.
