### PR TITLE
workflows: improve holdingpen data display

### DIFF
--- a/invenio/modules/workflows/engine.py
+++ b/invenio/modules/workflows/engine.py
@@ -413,7 +413,9 @@ BibWorkflowEngine
         """Halt the workflow (stop also any parent wfe)"""
         message = "Workflow '%s' halted at task %s with message: %s" % \
                   (self.name, self.get_current_taskname() or "Unknown", msg)
-        raise WorkflowHalt(message=message)
+        raise WorkflowHalt(message=message,
+                           widget=widget,
+                           id_workflow=self.uuid)
 
     def set_counter_initial(self, obj_count):
         self.db_obj.counter_initial = obj_count

--- a/invenio/modules/workflows/models.py
+++ b/invenio/modules/workflows/models.py
@@ -22,6 +22,7 @@ import tempfile
 import cPickle
 import base64
 import logging
+import six
 
 from datetime import datetime
 from sqlalchemy import desc
@@ -396,7 +397,7 @@ BibWorkflowObject
         tmp_fd, filename = tempfile.mkstemp(dir=directory,
                                             prefix=prefix,
                                             suffix=suffix)
-        os.write(tmp_fd, self._data)
+        os.write(tmp_fd, self.get_data())
         os.close(tmp_fd)
         return filename
 
@@ -417,6 +418,58 @@ BibWorkflowObject
         self.status = other.status
         self.data_type = other.data_type
         self.uri = other.uri
+
+    def get_formatted_data(self, format=None, formatter=None):
+        """
+        Returns the data in some chewable format.
+        """
+        from invenio.legacy.bibfield.bibfield_jsonreader import JsonReader
+        from invenio.modules.formatter.engine import format_record
+
+        data = self.get_data()
+
+        if formatter:
+            # A seperate formatter is supplied
+            return formatter(data)
+
+        if isinstance(data, dict):
+            # Dicts are cool on its own, but maybe its bibfield
+            try:
+                new_dict_representation = JsonReader()
+                new_dict_representation.rec_json = data
+                data = new_dict_representation.legacy_export_as_marc()
+            except Exception as e:
+                raise e
+
+        if isinstance(data, six.string_types):
+            # Its a string type, lets try to convert
+            if format:
+                # We can try formatter!
+                # If already XML, format_record does not like it.
+                if format != 'xm':
+                    try:
+                        return format_record(recID=None,
+                                             of=format,
+                                             xml_record=data)
+                    except TypeError as e:
+                        # Wrong kind of type
+                        pass
+                else:
+                    # So, XML then
+                    from xml.dom.minidom import parseString
+                    try:
+                        pretty_data = parseString(data)
+                        return pretty_data.toprettyxml()
+                    except TypeError:
+                        # Probably not proper XML string then
+                        return "Data cannot be parsed: %s" % (data,)
+                    except Exception:
+                        # Some other parsing error
+                        pass
+            # Just return raw string
+            return data
+        # Not any of the above types. How juicy!
+        return data
 
 
 class BibWorkflowObjectLog(db.Model):

--- a/invenio/modules/workflows/views/holdingpen.py
+++ b/invenio/modules/workflows/views/holdingpen.py
@@ -23,7 +23,6 @@ from flask.ext.login import login_required
 from ..models import BibWorkflowObject, Workflow
 from ..loader import widgets
 from invenio.base.decorators import templated, wash_arguments
-from invenio.modules.formatter.engine import format_record
 from invenio.base.i18n import _
 from flask.ext.breadcrumbs import default_breadcrumb_root, register_breadcrumb
 from flask.ext.menu import register_menu
@@ -252,8 +251,7 @@ def details(bwobject_id):
                            bwparent=extracted_data['bwparent'],
                            info=extracted_data['info'],
                            log=extracted_data['logtext'],
-                           data_preview=_entry_data_preview(
-                               bwobject.get_data(), recformat),
+                           data_preview=bwobject.get_formatted_data(recformat),
                            workflow_func=extracted_data['workflow_func'],
                            workflow=extracted_data['w_metadata'])
 
@@ -375,17 +373,21 @@ def resolve_widget(bwobject_id, widget):
 @blueprint.route('/entry_data_preview', methods=['GET', 'POST'])
 @login_required
 @wash_arguments({'oid': (unicode, '0'),
-                 'recformat': (unicode, 'default')})
+                 'recformat': (unicode, None)})
 def entry_data_preview(oid, recformat):
     """
     Presents the data in a human readble form or in xml code
     """
     from flask import jsonify, Markup
+    from pprint import pformat
 
     bwobject = BibWorkflowObject.query.get(int(oid))
 
-    formatted_data = _entry_data_preview(bwobject.get_data(), recformat)
-    if recformat in ("xm", "xml", "marcxml"):
+    formatted_data = bwobject.get_formatted_data(recformat)
+    if isinstance(formatted_data, dict):
+        formatted_data = pformat(formatted_data)
+
+    if recformat and recformat in ("xm", "xml", "marcxml"):
         data = Markup.escape(formatted_data)
     else:
         data = formatted_data
@@ -406,18 +408,6 @@ def get_info(bwobject):
     info['object id'] = bwobject.id
     info['widget'] = bwobject.get_extra_data()['widget']
     return info
-
-
-def _entry_data_preview(data, recformat='hd'):
-    """
-    Formats the data using format_record
-    """
-    if recformat != 'xm':
-        return format_record(recID=None, of=recformat, xml_record=data)
-    else:
-        from xml.dom.minidom import parseString
-        pretty_data = parseString(data)
-        return pretty_data.toprettyxml()
 
 
 def extract_data(bwobject):


### PR DESCRIPTION
- Adds a new function to BibWorkflowObject that tries to
  return a well formatted representation of the data.
- Improves the formatting sequence when displaying data from
  workflow objects in Holding Pen to not cause exceptions when
  data is non-XML. Data is now shown as a pretty string when
  not formattable by formatter or legacy.bibfield.
