### PR TITLE
comments: fixes

### DIFF
--- a/invenio/core/record/definitions.py
+++ b/invenio/core/record/definitions.py
@@ -26,7 +26,6 @@ __all__ = ['field_definitions', 'legacy_field_matchings', 'model_definitions']
 
 
 def _rebuild_cache():
-    print ">>> Recreating the cache for fields!"
     from invenio.core.record.config_engine import FieldParser
     field_definitions, legacy_field_matchings = FieldParser(
         'recordext.fields').create()

--- a/invenio/legacy/webcomment/templates.py
+++ b/invenio/legacy/webcomment/templates.py
@@ -1201,7 +1201,8 @@ class Template:
         if not nickname:
             (uid, nickname, display) = get_user_info(uid)
         if nickname:
-            note = _("Note: Your nickname, %s, will be displayed as author of this comment.") % ('<i>' + nickname + '</i>')
+            note = _("Note: Your nickname, %(nick)s, will be displayed as author of this comment.",
+                     nick='<i>' + nickname + '</i>')
         else:
             (uid, nickname, display) = get_user_info(uid)
             link = '<a href="%s/youraccount/edit">' % CFG_SITE_SECURE_URL

--- a/invenio/modules/comments/forms.py
+++ b/invenio/modules/comments/forms.py
@@ -38,7 +38,7 @@ class AddCmtRECORDCOMMENTForm(InvenioBaseForm):
             )
         )
     ])
-    in_reply_to_id_cmtRECORDCOMMENT = HiddenField()
+    in_reply_to_id_cmtRECORDCOMMENT = HiddenField(default=0)
 
 
 class AddCmtRECORDCOMMENTFormReview(AddCmtRECORDCOMMENTForm):


### PR DESCRIPTION
- pybabel fix;
- Default form value for in_reply is set to 0 in order to avoid inserting
  a string instead of an integer in the DB;
- Removes print statement.

Signed-off-by: Adrian-Tudor Panescu adrian.tudor.panescu@cern.ch
