### PR TITLE
Style: migration to twitter bootstrap 3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,351 +1,463 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2014 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Invenio is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Invenio; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
 'use strict';
 
 module.exports = function (grunt) {
-    // show elapsed time at the end
-    require('time-grunt')(grunt);
-    // load all grunt tasks
-    require('load-grunt-tasks')(grunt);
+	// show elapsed time at the end
+	require('time-grunt')(grunt);
+	// load all grunt tasks
+	require('load-grunt-tasks')(grunt);
 
-    // Project configuration
-    grunt.initConfig({
-        pkg: grunt.file.readJSON('package.json'),
+  var globalConfig = {
+    bower_path: 'bower_components',
+  };
 
-        copy: {
-            // css
-            css: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['bootstrap/docs/assets/css/bootstrap*.css'
-                     ,'jquery-tokeninput/styles/token-input-facebook.css'
-                     ,'jquery-tokeninput/styles/token-input.css'
-                     ,'jquery.bookmark/jquery.bookmark.css'
-                     ,'datatables-colvis/media/css/ColVis.css'],
-                dest: 'invenio/base/static/css/'
-            },
-            // images
-            img: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['bootstrap/docs/assets/img/glyphicons-halflings*.png'
-                     ,'jquery.bookmark/bookmarks.png'
-                     ,'uploadify/uploadify*'
-                     ,'!uploadify/uploadify.php'
-                     ,'datatables-colvis/media/images/button.png'],
-                dest: 'invenio/base/static/img/'
-            },
-            // javascript
-            js: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['bootstrap/docs/assets/js/bootstrap.js'
-                     ,'bootstrap/docs/assets/js/bootstrap.min.js' 
-                     ,'jquery/jquery.min.js'
-                     ,'jquery-tokeninput/src/jquery.tokeninput.js'
-                     ,'jquery.bookmark/jquery.bookmark.min.js'
-                     ,'DataTables/media/js/jquery.dataTables.js'
-                     ,'jquery-flot/excanvas.min.js'
-                     ,'jquery-flot/jquery.flot.js'
-                     ,'jquery-flot/jquery.flot.selection.js'
-                     ,'jquery.hotkeys/jquery.hotkeys.js'
-                     ,'uploadify/jquery.uploadify.min.js'
-                     ,'json2/json2.js'
-                     ,'datatables-colvis/media/js/ColVis.js'],
-                dest: 'invenio/base/static/js/'
-            },
+  var targets = {
+    develop: 'develop',
+    deploy: 'deploy'
+  };
 
-            hogan: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['hogan/web/builds/2.0.0/hogan-2.0.0.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    return dest + src.substring(0, src.indexOf('-')) + '.js';
-                }
-            },
+  var buildConfig = {
+    develop: 'instance/static',
+    deploy: 'invenio/base/static'
+  };
 
-            jqueryUI: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['jquery.ui/jquery-1.8.2.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    return dest + src.substring(0, src.indexOf('-')) + '-ui.js';
-                }
-            },
+	// Project configuration
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
+    globalConfig: globalConfig,
+    buildConfig: buildConfig,
 
-            jqueryTimePicker: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['jquery.ui.timepicker/index.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    var res = src.replace(src.substring(0),'jquery-ui-timepicker-addon.js');
-                    return dest + res;
-                }
-            },
+		copy: {
+			css: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>',
+				src: ['bootstrap/dist/css/bootstrap*.css'
+					   ,'jquery-tokeninput/styles/token-input-facebook.css'
+					   ,'jquery-tokeninput/styles/token-input.css'
+					   ,'jquery.bookmark/jquery.bookmark.css'
+					   ,'datatables-colvis/media/css/ColVis.css'],
+				dest: '<%= grunt.option(\'target\') %>/css/'
+			},
 
-            MultiFile: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['jquery.multifile/index.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    var res = src.replace(src.substring(0),'jquery.MultiFile.pack.js');
-                    return dest + res;
-                }
-            },
+			img: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['jquery.bookmark/bookmarks.png'
+					   ,'uploadify/uploadify*'
+					   ,'!uploadify/uploadify.php'
+					   ,'datatables-colvis/media/images/button.png'],
+				dest: '<%= grunt.option(\'target\') %>/img/'
+			},
 
-            ajaxPager: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['jquery.ajaxpager/index.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    var res = src.replace(src.substring(0),'jquery.ajaxPager.js');
-                    return dest + res;
-                }
-            },
+			js: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['bootstrap/dist/js/bootstrap.js'
+    				 ,'bootstrap/dist/js/bootstrap.min.js' 
+    				 ,'typeahead.js/dist/typeahead.js'
+    				 ,'typeahead.js/dist/typeahead.min.js'
+    				 ,'jquery/jquery.min.js'
+    				 ,'jquery-tokeninput/src/jquery.tokeninput.js'
+    				 ,'jquery.bookmark/jquery.bookmark.min.js'
+    				 ,'DataTables/media/js/jquery.dataTables.js'
+    				 ,'jquery-flot/excanvas.min.js'
+    				 ,'jquery-flot/jquery.flot.js'
+    				 ,'jquery-flot/jquery.flot.selection.js'
+    				 ,'jquery.hotkeys/jquery.hotkeys.js'
+    				 ,'uploadify/jquery.uploadify.min.js'
+    				 ,'json2/json2.js'
+    				 ,'datatables-colvis/media/js/ColVis.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/'
+			},
 
-            form: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['form/index.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    var res = src.replace(src.substring(0),'jquery.form.js');
-                    return dest + res;
-                }
-            },
+			fonts: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['bootstrap/dist/fonts/glyphicons-halflings-regular.*'],
+				dest: '<%= grunt.option(\'target\') %>/fonts/'
+			},
 
-            prism: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['prism/index.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    var res = src.replace(src.substring(0),'prism.js');
-                    return dest + res;
-                }
-            },
+			hogan: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['hogan/web/builds/2.0.0/hogan-2.0.0.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					return dest + src.substring(0, src.indexOf('-')) + '.js';
+				}
+			},
 
-            swfobject: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/',
-                src: ['swfobject/index.js'],
-                dest: 'invenio/base/static/js/',
-                rename: function(dest, src) {
-                    var res = src.replace(src.substring(0),'swfobject.js');
-                    return dest + res;
-                }
-            },
+			jqueryUI: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['jquery.ui/jquery-1.8.2.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					return dest + src.substring(0, src.indexOf('-')) + '-ui.js';
+				}
+			},
 
-            MathJax: {
-                expand: true,
-                cwd: 'bower_components/MathJax/',
-                src: ['**'],
-                dest: 'invenio/base/static/MathJax/'
-            },
+			jqueryTimePicker: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['jquery.ui.timepicker/index.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					var res = src.replace(src.substring(0),'jquery-ui-timepicker-addon.js');
+					return dest + res;
+				}
+			},
 
-            ckeditor: {
-                expand: true,
-                cwd: 'bower_components/ckeditor/',
-                src: ['**', '!**_samples/**', '!**_source/**', '!**php**', '!**_**', '!**pack**', '!**ckeditor.asp'],
-                dest: 'invenio/base/static/ckeditor/' 
-            },
+			MultiFile: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['jquery.multifile/index.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					var res = src.replace(src.substring(0),'jquery.MultiFile.pack.js');
+					return dest + res;
+				}
+			},
 
-            jqueryTreeview: {
-                expand: true,
-                cwd: 'bower_components/jquery.treeview/',
-                src: ['**'],
-                dest: 'invenio/base/static/js/jquery-treeview/'
-            },
+			ajaxPager: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['jquery.ajaxpager/index.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					var res = src.replace(src.substring(0),'jquery.ajaxPager.js');
+					return dest + res;
+				}
+			},
 
-            jqueryTableSorter: {
-                expand: true,
-                cwd: 'bower_components/jquery.tablesorter/',
-                src: ['**'],
-                dest: 'invenio/base/static/js/tablesorter/'
-            },
+			form: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['form/index.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					var res = src.replace(src.substring(0),'jquery.form.js');
+					return dest + res;
+				}
+			},
 
-            // jqueryUI 
-            themesUI: {
-                expand: true,
-                cwd: 'bower_components/jquery.ui/themes/',
-                src: ['**'],
-                dest: 'invenio/base/static/img/jquery-ui/'
-            },
+			prism: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['prism/index.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					var res = src.replace(src.substring(0),'prism.js');
+					return dest + res;
+				}
+			},
 
-            imagesUI: {
-                expand: true,
-                cwd: 'bower_components/jquery.ui/themes/base/images/',
-                src: ['**'],
-                dest: 'invenio/base/static/img/images/'
-            }
-        },
+			swfobject: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/',
+				src: ['swfobject/index.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				rename: function(dest, src) {
+					var res = src.replace(src.substring(0),'swfobject.js');
+					return dest + res;
+				}
+			},
 
-        // minification of the JS files
-        uglify: {
-            jeditable: {
-                expand: true,
-                flatten: true,
-                cwd: 'bower_components/jquery_jeditable/',
-                src: ['js/jquery.jeditable.js'],
-                dest: 'invenio/base/static/js/',
-                ext: '.jeditable.mini.js'
-            },
+			MathJax: {
+				expand: true,
+				cwd: '<%= globalConfig.bower_path %>/MathJax/',
+				src: ['**'],
+				dest: '<%= grunt.option(\'target\') %>/MathJax/'
+			},
 
-            jqueryUI: {
-                expand: true,
-                flatten: true,
-                cwd: 'invenio/base/static/js/',
-                src: ['jquery-ui.js'],
-                dest: 'invenio/base/static/js/',
-                ext: '.min.js'
-            },
+			ckeditor: {
+				expand: true,
+				cwd: '<%= globalConfig.bower_path %>/ckeditor/',
+				src: ['**', '!**_samples/**', '!**_source/**', '!**php**', '!**_**', '!**pack**', '!**ckeditor.asp'],
+				dest: '<%= grunt.option(\'target\') %>/ckeditor/' 
+			},
 
-            dataTables: {
-                expand: true,
-                flatten: true,
-                cwd: 'invenio/base/static/js/',
-                src: ['jquery.dataTables.js'],
-                dest: 'invenio/base/static/js/',
-                ext: '.dataTables.min.js'                
-            },
+			jqueryTreeview: {
+				expand: true,
+				cwd: '<%= globalConfig.bower_path %>/jquery.treeview/',
+				src: ['**'],
+				dest: '<%= grunt.option(\'target\') %>/js/jquery-treeview/'
+			},
 
-            jqueryFlot: {
-                expand: true,
-                flatten: true,
-                cwd: 'invenio/base/static/js/',
-                src: ['jquery.flot.js'],
-                dest: 'invenio/base/static/js/',
-                ext: '.flot.min.js'   
-            },
+			jqueryTableSorter: {
+				expand: true,
+				cwd: '<%= globalConfig.bower_path %>/jquery.tablesorter/',
+				src: ['**'],
+				dest: '<%= grunt.option(\'target\') %>/js/tablesorter/'
+			},
 
-            jqueryFlotSelection: {
-                expand: true,
-                flatten: true,
-                cwd: 'invenio/base/static/js/',
-                src: ['jquery.flot.selection.js'],
-                dest: 'invenio/base/static/js/',
-                ext: '.flot.selection.min.js'   
-            }
-        },
+			// jqueryUI 
+			themesUI: {
+				expand: true,
+				cwd: '<%= globalConfig.bower_path %>/jquery.ui/themes/',
+				src: ['**'],
+				dest: '<%= grunt.option(\'target\') %>/img/jquery-ui/'
+			},
 
-        // minification of the CSS files
-        cssmin: {
-            minify: {
-                expand: true,
-                cwd: 'invenio/base/static/css/',
-                src: ['bootstrap*.css', '!bootstrap*.min.css'],
-                dest: 'invenio/base/static/css/',
-                ext: '.min.css'
-            }
-        },
+			imagesUI: {
+				expand: true,
+				cwd: '<%= globalConfig.bower_path %>/jquery.ui/themes/base/images/',
+				src: ['**'],
+				dest: '<%= grunt.option(\'target\') %>/img/images/'
+			}
+		},
 
-        //////////////////////////////////////////////////////////////
-        /////////////////////// CLEANING..... ////////////////////////
-        //////////////////////////////////////////////////////////////
-        clean: {
-            css: {
-                expand: true,
-                cwd: 'invenio/base/static/css/',
-                src: ['bootstrap*.css'
-                     ,'token-input-facebook.css'
-                     ,'token-input.css'
-                     ,'jquery.bookmark.css'
-                     ,'ColVis.css']
-            },
+		// minification of the JS files
+		uglify: {
+			jeditable: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= globalConfig.bower_path %>/jquery_jeditable/',
+				src: ['js/jquery.jeditable.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				ext: '.jeditable.mini.js'
+			},
 
-            img: {
-                expand: true,
-                cwd: 'invenio/base/static/img/',
-                src: ['glyphicons-halflings*.png'
-                     ,'bookmarks.png'
-                     ,'uploadify*'
-                     ,'button.png']
-            },
+			jqueryUI: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= grunt.option(\'target\') %>/js/',
+				src: ['jquery-ui.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				ext: '.min.js'
+			},
 
-            js: {
-                expand: true,
-                cwd: 'invenio/base/static/js/',
-                src: ['bootstrap.js'
-                     ,'bootstrap.min.js' 
-                     ,'jquery.min.js'
-                     ,'jquery.tokeninput.js'
-                     ,'hogan.js'// hogan
-                     ,'jquery.jeditable.mini.js' // jeditable
-                     ,'jquery-ui*.js' // jqueryUI
-                     ,'jquery-ui-timepicker-addon.js' // timepicker
-                     ,'jquery.MultiFile.pack.js' // multifile
-                     ,'jquery.ajaxPager.js' // ajaxpager 
-                     ,'jquery.bookmark.min.js' // bookmark 
-                     ,'jquery.dataTables*.js' // dataTables
-                     ,'excanvas.min.js' // excanvas
-                     ,'jquery.flot*.js' // flot
-                     ,'jquery.form.js'  // form
-                     ,'jquery.hotkeys.js' // hotkeys
-                     ,'jquery.uploadify.min.js' // uploadify
-                     ,'json2.js' // json2
-                     ,'prism.js' // prism
-                     ,'swfobject.js' // swfobject
-                     ,'ColVis.js']  // ColVis
-            },
+			dataTables: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= grunt.option(\'target\') %>/js/',
+				src: ['jquery.dataTables.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				ext: '.dataTables.min.js'                
+			},
 
-            MathJax: {
-                expand: true,
-                cwd: 'invenio/base/static/MathJax/',
-                src: ['**']
-            },
+			jqueryFlot: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= grunt.option(\'target\') %>/js/',
+				src: ['jquery.flot.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				ext: '.flot.min.js'   
+			},
 
-            // TO DO: make it work keeping the folders included
-            // not working properly removes all the files
-            ckeditor: {
-                expand: true,
-                cwd: 'invenio/base/static/ckeditor/',
-                src: ["**", '!**plugins/scientificchar/**']
-            },
+			jqueryFlotSelection: {
+				expand: true,
+				flatten: true,
+				cwd: '<%= grunt.option(\'target\') %>/js/',
+				src: ['jquery.flot.selection.js'],
+				dest: '<%= grunt.option(\'target\') %>/js/',
+				ext: '.flot.selection.min.js'   
+			}
+		},
 
-            jqueryTreeview: {
-                expand: true,
-                cwd: 'invenio/base/static/js/jquery-treeview/',
-                src: ['**']
-            },
+		// minification of the CSS files
+		cssmin: {
+			minify: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/css/',
+				src: ['bootstrap*.css', '!bootstrap*.min.css'],
+				dest: '<%= grunt.option(\'target\') %>/css/',
+				ext: '.min.css'
+			}
+		},
 
-            jqueryTableSorter: {
-                expand: true,
-                cwd: 'invenio/base/static/js/tablesorter/',
-                src: ['**']
-            },
+		
+		//// CLEANING... ////
+		actualclean: {
+      css: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/css/',
+				src: ['bootstrap*.css'
+  					 ,'token-input-facebook.css'
+  					 ,'token-input.css'
+  					 ,'jquery.bookmark.css'
+  					 ,'ColVis.css']
+			},
+   		
+      img: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/img/',
+				src: ['bookmarks.png'
+  					 ,'uploadify*'
+  					 ,'button.png']
+			},
 
-            imagesUI: {
-                expand: true,
-                cwd: 'invenio/base/static/img/images/',
-                src: ['**'],
-            },
+			fonts: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/fonts/',
+				src: ['**']
+			},
+					   
+			js: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/js/',
+				src: ['bootstrap.js'
+  					 ,'bootstrap.min.js' 
+  					 ,'typeahead.js'
+  					 ,'typeahead.min.js'
+  					 ,'jquery.min.js'
+  					 ,'jquery.tokeninput.js'
+  					 ,'hogan.js'
+  					 ,'jquery.jeditable.mini.js' 
+  					 ,'jquery-ui*.js' 
+  					 ,'jquery-ui-timepicker-addon.js' 
+  					 ,'jquery.MultiFile.pack.js' 
+  					 ,'jquery.ajaxPager.js' 
+  					 ,'jquery.bookmark.min.js' 
+  					 ,'jquery.dataTables*.js' 
+  					 ,'excanvas.min.js' 
+  					 ,'jquery.flot*.js' 
+  					 ,'jquery.form.js'  
+  					 ,'jquery.hotkeys.js' 
+  					 ,'jquery.uploadify.min.js' 
+  					 ,'json2.js' 
+  					 ,'prism.js' 
+  					 ,'swfobject.js' 
+  					 ,'ColVis.js'] 
+			},
 
-            themesUI: {
-                expand: true,
-                cwd: 'invenio/base/static/img/jquery-ui/',
-                src: ['**'],
-            }
+			MathJax: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/MathJax/',
+				src: ['**']
+			},
+
+			ckeditor: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/ckeditor/',
+				src: ["**", '!**plugins/scientificchar/**']
+			},
+
+			jqueryTreeview: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/js/jquery-treeview/',
+				src: ['**']
+			},
+
+			jqueryTableSorter: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/js/tablesorter/',
+				src: ['**']
+			},
+
+			imagesUI: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/img/images/',
+				src: ['**']
+			},
+
+			themesUI: {
+				expand: true,
+				cwd: '<%= grunt.option(\'target\') %>/img/jquery-ui/',
+				src: ['**']
+			},
+
+      //clean the folder if it's empty
+      empty: {
+        src: '<%= grunt.option(\'target\') %>/**/*',
+        filter: function(filepath) {
+          return (grunt.file.isDir(filepath) && require('fs').readdirSync(filepath).length === 0);
         }
-
-
-    });
-
-    // RUN: `$ grunt clean` to clean all the installed dependencies
+      }
+		}
+	});
+	
+  // build task
+  grunt.registerTask('build', 'Set the output folder for the build.', function () {
     
-    grunt.registerTask('default', ['copy', 'uglify', 'cssmin']);
+    if (grunt.option('path') === undefined) {
+      if (grunt.option('target') === 'develop') {
+        grunt.option('target', buildConfig.develop);
+      } else if (grunt.option('target') === 'deploy') {
+        grunt.option('target', buildConfig.deploy);
+      } else if (grunt.option('target') === undefined) {
+        grunt.option('target', buildConfig.develop);
+      } else {
+        grunt.task.run('help');  
+        return;
+      }
+      grunt.task.run(['copy', 'uglify', 'cssmin']); 
+    } else {
+      grunt.option('target', grunt.option('path'));
+      grunt.task.run(['copy', 'uglify', 'cssmin']);   
+    }
+
+  });
+
+  // clean task
+  grunt.renameTask('clean', 'actualclean');
+
+  grunt.registerTask('clean', 'Clean the files.', function () {
+
+    if (grunt.option('path') === undefined) {
+      if (grunt.option('target') === 'develop') {
+        grunt.option('target', buildConfig.develop);
+      } else if (grunt.option('target') === 'deploy') {
+        grunt.option('target', buildConfig.deploy);
+      } else if (grunt.option('target') === undefined) {
+        grunt.option('target', buildConfig.develop);
+      } else {
+        grunt.task.run('help');  
+        return;
+      }
+      grunt.task.run('actualclean');
+    } else {
+      grunt.option('target', grunt.option('path'));
+      grunt.task.run('actualclean');
+    }
+
+  });
+
+  // help task
+  grunt.registerTask('help', 'Help menu.', function () {
+    grunt.log.writeln("\nAvailable options for Grunt" + "\n\n" +
+                      "Building:" + "\n" +
+                      "grunt build --target=develop # build for development mode" + "\n" +
+                      "grunt build --target=deploy  # build for deployment mode" + "\n" +
+                      "grunt build                  # build for development mode" + "\n\n" +
+                      "Building with custom paths:" + "\n" +
+                      "grunt build --path='path/to/folder'  # build for custom mode" + "\n\n" +
+                      "Cleaning:" + "\n" +
+                      "grunt clean --target=develop # clean for development mode" + "\n" +
+                      "grunt clean --target=deploy  # clean for deployment mode" + "\n" +
+                      "grunt clean                  # clean for development mode" + "\n\n" +
+                      "Cleaning with custom paths:" + "\n" +
+                      "grunt clean --path='path/to/folder'  # clean for custom mode" + "\n");
+  });
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,6 +99,18 @@ module.exports = function (grunt) {
 				dest: '<%= grunt.option(\'target\') %>/fonts/'
 			},
 
+      typeaheadJSbootstrap: {
+        expand: true,
+        flatten: true,
+        cwd: '<%= globalConfig.bower_path %>/',
+        src: ['typeahead.js-bootstrap/index.css'],
+        dest: '<%= grunt.option(\'target\') %>/css/',
+        rename: function(dest, src) {
+          var res = src.replace(src.substring(0),'typeahead.js-bootstrap.css');
+          return dest + res;
+        }
+      },
+
 			hogan: {
 				expand: true,
 				flatten: true,
@@ -306,7 +318,8 @@ module.exports = function (grunt) {
   					 ,'token-input-facebook.css'
   					 ,'token-input.css'
   					 ,'jquery.bookmark.css'
-  					 ,'ColVis.css']
+  					 ,'ColVis.css'
+             ,'typeahead.js-bootstrap.css']
 			},
    		
       img: {

--- a/Makefile.am
+++ b/Makefile.am
@@ -53,7 +53,7 @@ dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version
 
 # Bootstrap version
-BOOTSTRAPV = 2.2.1
+BOOTSTRAPV = 3.0.2
 
 # Hogan.js version
 HOGANVER = 2.0.0
@@ -329,30 +329,44 @@ install-bootstrap:
 	rm -rf /tmp/invenio-bootstrap
 	mkdir /tmp/invenio-bootstrap
 	(cd /tmp/invenio-bootstrap && \
-	wget -O bootstrap.zip 'http://invenio-software.org/download/bootstrap/bootstrap-${BOOTSTRAPV}.zip' && \
+	wget -O bootstrap.zip 'https://github.com/twbs/bootstrap/releases/download/v${BOOTSTRAPV}/bootstrap-${BOOTSTRAPV}-dist.zip' && \
 	unzip -u bootstrap.zip && \
-	cp bootstrap/css/bootstrap-responsive.css ${prefix}/var/www/css/bootstrap-responsive.css && \
-	cp bootstrap/css/bootstrap-responsive.min.css ${prefix}/var/www/css/bootstrap-responsive.min.css && \
-	cp bootstrap/css/bootstrap.css ${prefix}/var/www/css/bootstrap.css && \
-	cp bootstrap/css/bootstrap.min.css ${prefix}/var/www/css/bootstrap.min.css && \
-	cp bootstrap/img/glyphicons-halflings-white.png ${prefix}/var/www/img/glyphicons-halflings-white.png && \
-	cp bootstrap/img/glyphicons-halflings.png ${prefix}/var/www/img/glyphicons-halflings.png && \
-	cp bootstrap/js/bootstrap.js ${prefix}/var/www/js/bootstrap.js && \
-	cp bootstrap/js/bootstrap.min.js ${prefix}/var/www/js/bootstrap.min.js && \
+	cp dist/css/bootstrap.css ${prefix}/var/www/css/bootstrap.css && \
+	cp dist/css/bootstrap.min.css ${prefix}/var/www/css/bootstrap.min.css && \
+	cp dist/css/bootstrap-theme.css ${prefix}/var/www/css/bootstrap-theme.css && \
+	cp dist/css/bootstrap-theme.min.css ${prefix}/var/www/css/bootstrap-theme.min.css && \
+	mkdir -p ${prefix}/var/www/fonts && \
+	cp dist/fonts/glyphicons-halflings-regular.eot ${prefix}/var/www/fonts/glyphicons-halflings-regular.eot && \
+	cp dist/fonts/glyphicons-halflings-regular.svg ${prefix}/var/www/fonts/glyphicons-halflings-regular.svg && \
+	cp dist/fonts/glyphicons-halflings-regular.ttf ${prefix}/var/www/fonts/glyphicons-halflings-regular.ttf && \
+	cp dist/fonts/glyphicons-halflings-regular.woff ${prefix}/var/www/fonts/glyphicons-halflings-regular.woff && \
+	cp dist/js/bootstrap.js ${prefix}/var/www/js/bootstrap.js && \
+	cp dist/js/bootstrap.min.js ${prefix}/var/www/js/bootstrap.min.js && \
+	wget -O bootstrap-typeahead.zip 'http://twitter.github.com/typeahead.js/releases/latest/typeahead.js.zip' && \
+	unzip -u bootstrap-typeahead.zip && \
+	cp typeahead.js/typeahead.js ${prefix}/var/www/js/typeahead.js && \
+	cp typeahead.js/typeahead.min.js ${prefix}/var/www/js/typeahead.min.js && \
+	wget -O typeahead.js-bootstrap.css 'https://raw.github.com/jharding/typeahead.js-bootstrap.css/master/typeahead.js-bootstrap.css' && \
+	mv typeahead.js-bootstrap.css ${prefix}/var/www/css/typeahead.js-bootstrap.css && \
 	rm -fr /tmp/invenio-bootstrap )
 	@echo "***********************************************************"
 	@echo "** The Twitter Bootstrap was successfully installed.     **"
 	@echo "***********************************************************"
 
 uninstall-bootstrap:
-	rm ${prefix}/var/www/css/bootstrap-responsive.css && \
-	rm ${prefix}/var/www/css/bootstrap-responsive.min.css && \
 	rm ${prefix}/var/www/css/bootstrap.css && \
 	rm ${prefix}/var/www/css/bootstrap.min.css && \
-	rm ${prefix}/var/www/img/glyphicons-halflings-white.png && \
-	rm ${prefix}/var/www/img/glyphicons-halflings.png && \
+	rm ${prefix}/var/www/css/bootstrap-theme.css && \
+	rm ${prefix}/var/www/css/bootstrap-theme.min.css && \
+	rm ${prefix}/var/www/css/typeahead.js-bootstrap.css && \
+	rm ${prefix}/var/www/fonts/glyphicons-halflings-regular.eot && \
+	rm ${prefix}/var/www/fonts/glyphicons-halflings-regular.svg && \
+	rm ${prefix}/var/www/fonts/glyphicons-halflings-regular.ttf && \
+	rm ${prefix}/var/www/fonts/glyphicons-halflings-regular.woff && \
 	rm ${prefix}/var/www/js/bootstrap.js && \
-	rm ${prefix}/var/www/js/bootstrap.min.js
+	rm ${prefix}/var/www/js/bootstrap.min.js && \
+	rm ${prefix}/var/www/js/typeahead.js && \
+	rm ${prefix}/var/www/js/typeahead.min.js
 	@echo "***********************************************************"
 	@echo "** The Twitter Bootstrap was successfully uninstalled.   **"
 	@echo "***********************************************************"
@@ -386,6 +400,8 @@ install-typeahead-plugin:
 	(cd /tmp/typeahead && \
 	wget -O typeahead.min.js 'http://twitter.github.com/typeahead.js/releases/latest/typeahead.min.js' && \
 	cp typeahead.min.js ${prefix}/var/www/js/typeahead.min.js && \
+	wget -O typeahead.js-bootstrap.css 'https://raw.github.com/jharding/typeahead.js-bootstrap.css/master/typeahead.js-bootstrap.css' && \
+	cp typeahead.js-bootstrap.css ${prefix}/var/www/css/typeahead.js-bootstrap.css && \
 	rm -fr /tmp/typeahead )
 	@echo "***********************************************************"
 	@echo "** typeahead.js was successfully installed.              **"

--- a/bower.json
+++ b/bower.json
@@ -2,11 +2,12 @@
   "name": "invenio-grunt",
   "version": "0.1.0",
   "dependencies": {
-    "bootstrap": "2.2.1",
-    "jquery": "1.8.3",
-    "hogan": "3.0.0"
+    "bootstrap": "3.0.2",
+    "jquery": "2.0.3"
   },
   "devDependencies": {
+    "typeahead.js": "*",
+    "hogan": "3.0.0",
     "jquery-tokeninput": "*",
     "ckeditor": "http://invenio-software.org/download/ckeditor/ckeditor_3.6.6.zip",
     "MathJax": "v2.1-latest",

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "json2": "*",
     "prism": "https://github.com/LeaVerou/prism/blob/gh-pages/prism.js",
     "swfobject": "https://github.com/swfobject/swfobject/blob/master/swfobject/swfobject.js",
-    "datatables-colvis": "*"
+    "datatables-colvis": "*",
+    "typeahead.js-bootstrap": "https://raw.github.com/jharding/typeahead.js-bootstrap.css/master/typeahead.js-bootstrap.css"
   }
 }

--- a/invenio/base/static/css/base.css
+++ b/invenio/base/static/css/base.css
@@ -1,0 +1,89 @@
+body {
+	padding-top: 70px;
+}
+
+footer a, footer a:hover {
+  color: #666;
+}
+footer, footer p {
+  font-size: 11px;
+  color: #333;
+}
+
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+	font-weight: bold;
+}
+
+/* Lastly, apply responsive CSS fixes as necessary */
+@media (max-width: 767px) {
+  footer {
+    margin-left: -20px;
+    margin-right: -20px;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}
+
+.navbar-brand img {
+	height: 20px;
+	opacity: 0.6;
+}
+
+.navbar-brand:hover img {
+	opacity: 0.95;
+}
+
+/* to display icon inline with text at a button */
+
+.btn-inline-icon-hide-sm span {
+	display: inline !important; /* to overwrite bootstrap's important */
+}
+
+@media (max-width: 992px) {
+	.btn-inline-icon-hide-sm span {
+		display: none !important; /* to overwrite important above*/
+	}	
+}
+
+/* to make inline sub-forms fields stick togeter */
+
+.right-not-rounded {
+	border-bottom-right-radius: 0px;
+	border-top-right-radius: 0px;
+}
+
+.left-not-rounded {
+	border-bottom-left-radius: 0px;
+	border-top-left-radius: 0px;
+}
+
+.no-padding {
+	padding: 0px;
+}
+
+/* END */
+
+/* typeahead fixes  */
+/* source http://www.aureliomerenda.com/install-typeahead-bootstrap-3-fix-css-overlay-width-100/ */
+
+.twitter-typeahead {
+     width: 100%;
+}
+
+.twitter-typeahead .tt-hint {
+    display: block;
+    height: 34px;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.428571429;
+    border: 1px solid transparent;
+    border-radius:4px;
+    width: 100%;
+}
+
+.tt-dropdown-menu
+{
+    width: 100%;
+}
+
+/* END typeahead fixes END */

--- a/invenio/base/templates/404.html
+++ b/invenio/base/templates/404.html
@@ -21,7 +21,7 @@
 {% block body %}
 
 <div class="row">
-  <div class="offset3 span6 alert alert-error" align="center">
+  <div class="col-md-offset-3 col-md-6 alert alert-danger" align="center">
     <div class="page-header">
       <h1>{{ _("404: Page Not Found") }}</h1>
     </div>

--- a/invenio/base/templates/_formhelpers.html
+++ b/invenio/base/templates/_formhelpers.html
@@ -20,19 +20,31 @@
 ## See http://flask.pocoo.org/docs/patterns/wtforms/
 #}
 {% macro render_field(field, show_error_list=True) %}
+  {% set label_size = kwargs.get('label_size') %}
+  {% set field_size = kwargs.get('field_size') %}
   {%- if field.name == "csrf_token" or field.type == 'HiddenField' -%}
   {{ field(**kwargs)|safe }}
   {%- else -%}
-  <div class="control-group {% if show_error_list and field.errors %} error{% endif %}">
-    {{ field.label(class="control-label") }}
-    <div class="controls">
+  <div class="form-group {% if show_error_list and field.errors %} error{% endif %}">
+    {% set label_classes = "control-label" %}
+    {% if label_size %}
+      {% set label_classes = label_classes + ' col-md-' + label_size|string %}
+    {% endif %}
+    {{ field.label(class_=label_classes) }}
+    {% set classes = kwargs.get('class_', '') + ' form-control' %}
+    {% do kwargs.update({'class_': classes }) %}
+    {% if field_size %}
+      <div class="col-md-{{field_size|string}}">
+    {% endif %}
     {{ field(**kwargs)|safe }}
     {% if show_error_list and field.errors %}
       {% for error in field.errors %}
       <span class="help-inline">{{ error }}</span>
       {% endfor %}
     {% endif %}
-    </div>
+    {% if field_size %}
+      </div>
+    {% endif %}
   </div>
   {%- endif -%}
 {% endmacro %}
@@ -64,9 +76,9 @@
 ## Field input wrapper.
 #}
 {% macro _filter_element(field) %}
-  <div class="input-append filter_element">
-    {{ field }}<span class="add-on remove-field" onclick="$(this).parent().remove()">
-      <i class="icon-minus"></i>
+  <div class="input-group filter_element">
+    {{ field }}<span class="input-group-addon remove-field" onclick="$(this).parent().remove()">
+      <i class="glyphicon glyphicon-minus"></i>
     </span>
   </div>
 {% endmacro %}
@@ -76,10 +88,10 @@
 ## elements for dynamic field manipulation.
 #}
 {% macro filter_field(field) %}
-<div class="control-group">
+<div class="form-group">
   {{ field.label(class="control-label") }}
   <div class="controls">
-    <div class="span6 paste">
+    <div class="col-md-6 paste">
     {% if field.raw_data %}
     {% for i in range(field.raw_data|count) %}
       {{ _filter_element(field) }}
@@ -89,7 +101,7 @@
     {% endif %}
     </div>
     <span class="pull-right btn btn-primary add-field" onclick="$('#field_copy_{{ field.id }}').children().clone().appendTo($(this).siblings('.paste'));">
-      <i class="icon-plus icon-white"></i>
+      <i class="glyphicon glyphicon-plus"></i>
     </span>
   </div>
 </div>

--- a/invenio/base/templates/admin_base.html
+++ b/invenio/base/templates/admin_base.html
@@ -16,12 +16,12 @@
 {% block page_body %}
 <div class="container">
 <div class="row">
-    <div class="span3">
+    <div class="col-md-3">
         <ul class="nav nav-tabs nav-stacked">
             {{ layout.menu() }}
         </ul>
     </div>
-    <div class="span9">
+    <div class="col-md-9">
         {% if admin_view.name %}<h4>{{admin_view.name}}</h4>{% endif %}
         {{ layout.messages() }}
         {% block body %}{% endblock %}

--- a/invenio/base/templates/breadcrumbs.html
+++ b/invenio/base/templates/breadcrumbs.html
@@ -29,7 +29,7 @@
       <a href="{{ breadcrumb.url }}"
          class="navtrail">
         {{ breadcrumb.text|safe }}
-      </a> <span class="divider">/</span>
+      </a>
     </li>
     {% endif %}
     {% endfor %}

--- a/invenio/base/templates/footer.html
+++ b/invenio/base/templates/footer.html
@@ -27,7 +27,7 @@
 <div class="container">
   <hr/>
   <div class="row">
-  <div class="span6">
+  <div class="col-md-6">
   {{ config["CFG_SITE_NAME_INTL"][g.ln] }} &nbsp;::&nbsp;<a class="footer" href="{{ url_for('') }}">{{ _("Search") }}</a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('submit') }}">{{ _("Submit") }}</a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('webaccount.index') }}">{{ _("Personalize") }}</a>&nbsp;::&nbsp;<a class="footer" href="{{ url_for('help') }}">{{ _("Help") }}</a>
   <br />
   {{ _("Powered by") }} <a class="footer" href="http://invenio-software.org/">Invenio</a> v{{ config.CFG_VERSION }}
@@ -38,7 +38,7 @@
       {{ _("Last updated") }}: {{ lastupdated|invenio_format_date }}
   {% endif %}
   </div>
-  <div class="span6">
+  <div class="col-md-6">
     <p style="text-align: right">
       {% if config.CFG_LANGUAGE_LIST_LONG %}
           {{ _("This site is also available in the following languages:") }} <br />

--- a/invenio/base/templates/header.html
+++ b/invenio/base/templates/header.html
@@ -24,84 +24,70 @@
 ## {% include 'header.html' %}
 #}
 
-  <style>
-  .brand img {
-    height: 20px;
-    width: auto!important;
-    max-width: 200%!important;
-    opacity: 0.6;
-  }
 
-  .brand:hover img {
-    opacity: 0.95;
-  }
-  </style>
-  <div class="navbar navbar-fixed-top navbar-inverse">
-    <div class="navbar-inner">
-      <div class="container">
-        <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-        </a>
-        <a class="brand" href="{{ url_for('search.index') }}">
+  <nav class="navbar navbar-fixed-top navbar-inverse" role="navigation">
+    <div class="container">
+      <div class="navbar-header">
+        <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".navbar-collapse">
+          <span class="sr-only">{{ _('Toggle navigation') }}</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="{{ url_for('search.index') }}">
           <img src="{{ url_for('static', filename='img/logo_white.png') }}" alt="{{ config.CFG_SITE_NAME_INTL[g.ln] }}" />
-        </a>
-        <div class="nav-collapse collapse">
-          <ul class="nav">
-          {%- for item in current_menu.submenu('main').children if item.visible recursive %}
-            {%- if item.children -%}
-            <li class="dropdown">
-              <a href="{{ item.url }}" style="display: inline-block; padding-right: 5px;">{{ item.text|safe }}</a>
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" style="display: inline-block; padding-left: 5px;">
-                <b class="caret"></b>
-              </a>
-              <ul class="dropdown-menu pull-right">
-                {{ loop(item.children) }}
-              </ul>
-            </li>
-            {%- else -%}
-            <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
-            {%- endif %}
-          {%- endfor %}
-          </ul>
-
-          <div class="pull-right">
-            <ul class="nav pull-right">
-              <li class="dropdown">
-              {% if current_user.is_guest %}
-                <a href="{{ url_for('webaccount.login', referer=request.url) }}" style="display: inline-block; padding-right: 5px;">
-                  <i class="icon icon-white icon-user"></i> {{ _("guest") }}
-                </a>
-              {% else %}
-                <a href="{{ url_for('webaccount.index') }}" style="display: inline-block; padding-right: 5px;">
-                  <i class="icon icon-white icon-user"></i> {{ current_user.nickname|default(current_user.email) }}
-                </a>
-              {% endif %}
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown" style="display: inline-block; padding-left: 5px;">
-                <span class="caret"></span>&nbsp;</a>
-                <ul class="dropdown-menu pull-right">
-                  {%- for item in current_menu.submenu('personalize').children if item.visible %}
-                  <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
-                  {% endfor %}
-                  <li class="divider"></li>
-                  {% if current_user.is_guest %}
-                  <li><a href="{{ url_for('webaccount.login', referer=request.url) }}">
-                    <i class="icon icon-lock"></i> {{ _("Login") }}
-                  </a></li>
-                  {% else %}
-                  <li><a href="{{ url_for('webaccount.logout') }}">
-                    <i class="icon icon-off"></i> {{ _("Logout") }}
-                  </a></li>
-                  {% endif %}
-                </ul>
-              </li>
+      </a>
+      </div>
+  
+      <div class="navbar-collapse collapse">
+        <ul class="nav navbar-nav">
+        {%- for item in current_menu.submenu('main').children if item.visible recursive %}
+          {%- if item.children -%}
+          <li class="dropdown">
+            <a href="{{ item.url }}" style="display: inline-block; padding-right: 5px;">{{ item.text|safe }}</a>
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" style="display: inline-block; padding-left: 5px;">
+              <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu pull-right">
+              {{ loop(item.children) }}
             </ul>
-          </div>
-        </div>
+          </li>
+          {%- else -%}
+          <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
+          {%- endif %}
+        {%- endfor %}
+        </ul>
+
+        <ul class="nav navbar-nav navbar-right">
+          <li class="dropdown">
+          {% if current_user.is_guest %}
+            <a href="{{ url_for('webaccount.login', referer=request.url) }}" style="display: inline-block; padding-right: 5px;">
+              <i class="glyphicon glyphicon-user"></i> {{ _("guest") }}
+            </a>
+          {% else %}
+            <a href="{{ url_for('webaccount.index') }}" style="display: inline-block; padding-right: 5px;">
+              <i class="glyphicon glyphicon-user"></i> {{ current_user.nickname|default(current_user.email) }}
+            </a>
+          {% endif %}
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" style="display: inline-block; padding-left: 5px;">
+            <span class="caret"></span>&nbsp;</a>
+            <ul class="dropdown-menu">
+              {%- for item in current_menu.submenu('personalize').children if item.visible %}
+              <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
+              {% endfor %}
+              <li class="divider"></li>
+              {% if current_user.is_guest %}
+              <li><a href="{{ url_for('webaccount.login', referer=request.url) }}">
+                <i class="glyphicon glyphicon-lock"></i> {{ _("Login") }}
+              </a></li>
+              {% else %}
+              <li><a href="{{ url_for('webaccount.logout') }}">
+                <i class="glyphicon glyphicon-off"></i> {{ _("Logout") }}
+              </a></li>
+              {% endif %}
+            </ul>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-
-  <div class="visible-desktop" style="clear:both; height: 60px;"></div>
-
+  </nav>

--- a/invenio/base/templates/legacy_page.html
+++ b/invenio/base/templates/legacy_page.html
@@ -21,7 +21,7 @@
 {% block title %}
 {% if title and show_title_p %}
 <div class="row">
-<div class="span12">
+<div class="col-md-12">
   <div class="page-header"><h1>
     {{titleprologue|safe}}{{title|safe}}{{titleepilogue|safe}}
   </h1></div>
@@ -44,7 +44,7 @@
 {% block breadcrumb %}
 <div class="container">
   <div class="row">
-    <div class="span12">
+    <div class="col-md-12">
       {{navtrailbox|safe}}
     </div>
   </div>
@@ -54,7 +54,7 @@
 
 {% block body %}
 <div class="row">
-<div class="span12">
+<div class="col-md-12">
 {{pageheaderadd}}
 <div class="pagebody">
   <div class="pagebodystripeleft">

--- a/invenio/base/templates/page_base.html
+++ b/invenio/base/templates/page_base.html
@@ -20,12 +20,13 @@
 {# Global CSS #}
 {% block global_css %}
   {%- css 'css/bootstrap.css', '00-invenio' -%}
-  {%- css 'css/bootstrap-responsive.min.css', '00-invenio' -%}
+  {%- css 'css/typeahead.js-bootstrap.css', '00-invenio' -%}
   {%- css 'css/token-input.css', '00-invenio' -%}
   {%- css 'css/token-input-facebook.css', '00-invenio' -%}
+  {%- css url_for('static', filename='css/base.css'), '00-invenio' -%}
   {%- css url_for('webtag.static', filename='css/tags/popover.css'), '00-invenio' -%}
   {%- if config.CFG_WEBSTYLE_TEMPLATE_SKIN != 'default' %}
-  {%- css 'css/'+config.CFG_WEBSTYLE_TEMPLATE_SKIN, '00-invenio' -%}
+    {%- css 'css/'+config.CFG_WEBSTYLE_TEMPLATE_SKIN, '00-invenio' -%}
   {%- endif %}
 {% endblock global_css %}
 
@@ -38,6 +39,7 @@
   {%- js 'js/jquery.jeditable.mini.js', '00-invenio' -%}
   {%- js 'js/invenio.js', '00-invenio' -%}
   {%- js 'js/translate.js', '00-invenio' -%}
+  {%- js 'js/typeahead.js', '00-invenio' -%}
 {% endblock global_javascript %}
 
 {%- if not no_pageheader -%}

--- a/invenio/ext/email/__init__.py
+++ b/invenio/ext/email/__init__.py
@@ -233,7 +233,15 @@ def send_email(fromaddr,
             register_exception()
             if debug_level > 1:
                 try:
-                    raise EmailError(g._('Error in sending message. Waiting %s seconds. Exception is %s, while sending email from %s to %s with body %s.') % (attempt_sleeptime, sys.exc_info()[0], fromaddr, toaddr, body))
+                    raise EmailError(g._('Error in sending message. \
+                        Waiting %(sec)s seconds. Exception is %(exc)s, \
+                        while sending email from %(sender)s to %(receipient)s \
+                        with body %(email_body)s.', \
+                        sec = attempt_sleeptime, \
+                        exc = sys.exc_info()[0], \
+                        sender = fromaddr, \
+                        receipient = toaddr, \
+                        email_body = body))
                 except EmailError:
                     register_exception()
         if not sent:

--- a/invenio/legacy/bibclassify/keyword_analyzer.py
+++ b/invenio/legacy/bibclassify/keyword_analyzer.py
@@ -152,8 +152,8 @@ def get_composite_keywords(ckw_db, fulltext, skw_spans):
             else:
                 previous_spans = spans[index]
 
-            for new_span in [(span0, span1) for span0 in previous_spans
-                                            for span1 in spans[index + 1]]:
+            for new_span in [(span0, col-md-1) for span0 in previous_spans
+                                            for col-md-1 in spans[index + 1]]:
                 span = _get_ckw_span(fulltext, new_span)
                 if span is not None:
                     ckw_spans.append(span)
@@ -162,8 +162,8 @@ def get_composite_keywords(ckw_db, fulltext, skw_spans):
             if index > 0 and ckw_spans:
                 _ckw_spans = []
                 for _span in ckw_spans[len_ckw:]: # new spans
-                    for _span2 in ckw_spans[:len_ckw]:
-                        s = _span_overlapping(_span, _span2)
+                    for _col-md-2 in ckw_spans[:len_ckw]:
+                        s = _span_overlapping(_span, _col-md-2)
                         if s:
                             _ckw_spans.append(s)
                 ckw_spans = _ckw_spans
@@ -315,11 +315,11 @@ def _get_ckw_span(fulltext, spans):
     # There is no inclusion.
     return None
 
-def _contains_span(span0, span1):
-    """Return true if span0 contains span1, False otherwise."""
-    if (span0 == span1 or
-        span0[0] > span1[0] or
-        span0[1] < span1[1]):
+def _contains_span(span0, col-md-1):
+    """Return true if span0 contains col-md-1, False otherwise."""
+    if (span0 == col-md-1 or
+        span0[0] > col-md-1[0] or
+        span0[1] < col-md-1[1]):
         return False
     return True
 

--- a/invenio/legacy/oaiharvest/web/admin/oai_harvest_admin.js
+++ b/invenio/legacy/oaiharvest/web/admin/oai_harvest_admin.js
@@ -18,9 +18,9 @@
  */
 
 $(function() {
-        $( "#holdingpencontainer" ).accordion({collapsible: true, autoHeight: false});
-        $( "#holdingpencontainer > div" ).accordion({collapsible: true, autoHeight: false});
-        $( "#holdingpencontainer > div > div" ).accordion({collapsible: true, active: false, autoHeight: false, clearStyle: true});
+        $( "#holdingpencontainer" ).panel-group ({collapsible: true, autoHeight: false});
+        $( "#holdingpencontainer > div" ).panel-group ({collapsible: true, autoHeight: false});
+        $( "#holdingpencontainer > div > div" ).panel-group ({collapsible: true, active: false, autoHeight: false, clearStyle: true});
 
         $( "#holdingpencontainer > div > div").bind("accordionchangestart", function(event, ui) {
             console.dir(ui.newHeader); // jQuery, activated header

--- a/invenio/legacy/webbasket/templates.py
+++ b/invenio/legacy/webbasket/templates.py
@@ -40,26 +40,26 @@ from invenio.utils.date import convert_datetext_to_dategui
 from invenio.legacy.webbasket.db_layer import get_basket_ids_and_names
 
 ICON_BACK = 'icon-arrow-left'
-ICON_CREATE_BASKET = 'icon-plus'
+ICON_CREATE_BASKET = 'glyphicon glyphicon-plus'
 ICON_EDIT_BASKET = 'icon-wrench'
 ICON_DELETE_BASKET = 'icon-trash'
 
-ICON_ADD_ITEM = 'icon-plus'
+ICON_ADD_ITEM = 'glyphicon glyphicon-plus'
 ICON_MOVE_ITEM = 'icon-share-alt'
-ICON_COPY_ITEM = 'icon-plus-sign'
+ICON_COPY_ITEM = 'glyphicon glyphicon-plus-sign'
 ICON_REMOVE_ITEM = 'icon-trash'
 
 ICON_MOVE_UP = 'icon-arrow-up'
-ICON_MOVE_UP_MUTED = 'icon-arrow-up muted'
+ICON_MOVE_UP_MUTED = 'icon-arrow-up text-muted'
 ICON_MOVE_DOWN = 'icon-arrow-down'
-ICON_MOVE_DOWN_MUTED = 'icon-arrow-down muted'
+ICON_MOVE_DOWN_MUTED = 'icon-arrow-down text-muted'
 ICON_NEXT_ITEM = 'icon-arrow-right'
-ICON_NEXT_ITEM_MUTED = 'icon-arrow-right muted'
+ICON_NEXT_ITEM_MUTED = 'icon-arrow-right text-muted'
 ICON_PREVIOUS_ITEM = 'icon-arrow-left'
-ICON_PREVIOUS_ITEM_MUTED = 'icon-arrow-left muted'
+ICON_PREVIOUS_ITEM_MUTED = 'icon-arrow-left text-muted'
 
 ICON_NOTES = 'icon-file'
-ICON_ADD_NOTE = 'icon-pencil'
+ICON_ADD_NOTE = 'glyphicon glyphicon-pencil'
 
 
 class Template:
@@ -146,10 +146,10 @@ class Template:
                                    'label': _('Edit topic')}
                 personal_tab = """
               <div class="row-fluid">
-                <div class="span7 bsk_directory_box_nav_tab_content">
+                <div class="col-md-7 bsk_directory_box_nav_tab_content">
                   %(personalbaskets_link)s&nbsp;&gt;&nbsp;%(topic_link)s
                 </div>
-                <div class="span5 pagination-right bsk_directory_box_nav_tab_options">
+                <div class="col-md-5 pagination-right bsk_directory_box_nav_tab_options">
                   %(go_back)s
                   &nbsp;&nbsp;
                   %(create_basket)s
@@ -253,7 +253,7 @@ class Template:
 
         if personal_baskets_info:
             tabs += """
-            <div class="span12">
+            <div class="col-md-12">
               %s
             </div>""" % (personal_tab,)
 
@@ -261,7 +261,7 @@ class Template:
         ## and the options on it.
         elif group_baskets_info:
             tabs += """
-            <div class="span12">
+            <div class="col-md-12">
               %s
             </div>""" % (group_tab,)
         ## If only a sepcific category is selected (or eveb none) display
@@ -269,13 +269,13 @@ class Template:
         else:
             tabs += """
 
-            <div class="span4">
+            <div class="col-md-4">
                 %(personal_tab)s
             </div>
-            <div class="span4">
+            <div class="col-md-4">
                 %(group_tab)s
             </div>
-            <div class="span4">
+            <div class="col-md-4">
                 %(public_tab)s
             </div>""" % {'personal_tab': personal_tab,
                          'group_tab': group_tab,
@@ -353,7 +353,7 @@ class Template:
             content_list.reverse()
             content = """
                 <div class="row-fluid">
-                    <div class="span12">
+                    <div class="col-md-12">
                         <table cellspacing="0px" cellpadding="0px" align="center" width="100%">
                           <tr>"""
             for i in range(nb_cells):
@@ -381,7 +381,7 @@ class Template:
                                       'label': _('Create basket')}
                 content += """
                 <div class="row-fluid well">
-                    <div class="span5 offset7 pagination-right bsk_directory_box_nav_extra_options">
+                    <div class="col-md-5 offset7 pagination-right bsk_directory_box_nav_extra_options">
                         %s
                     </div>
                 </div>""" % (create_basket_link,)
@@ -520,7 +520,7 @@ class Template:
         %(tabs)s
       </div>
       <div class="row-fluid bsk_directory_box_content">
-        <div class="span12 %(class)s">
+        <div class="col-md-12 %(class)s">
           %(content)s
         </div>
       </div>
@@ -1417,10 +1417,10 @@ class Template:
         out = """
 <div class="bskbasket">
     <div class="row-fluid bskbasketheader">
-        <div class="span1 bskactions">
+        <div class="col-md-1 bskactions">
             <img src="%(logo)s" alt="%(label)s" />
         </div>
-        <div class="span11 bsktitle">
+        <div class="col-md-11 bsktitle">
             <b>%(label)s</b><br />
             %(count)s
         </div>
@@ -1672,15 +1672,15 @@ class Template:
     <div class="bskbasket">
         <div class="well bskbasketheader">
             <div class="row-fluid bskactions">
-                <div class="span1 bskactions">
+                <div class="col-md-1 bskactions">
                     <img src="%(logo)s" alt="%(label)s" />
                 </div>
-                <div class="span11 bsktitle">
+                <div class="col-md-11 bsktitle">
                     <b>Adding items to your basket</b>
                 </div>
             </div>
             <div class="row-fluid bskbasketheader bskactions">
-                <div class="span12">
+                <div class="col-md-12">
                     To add internal items to your basket please select them
                     through the  <a href="%(search_link)s">search page</a>
                     and use the "Add to basket" functionality.
@@ -1722,7 +1722,7 @@ class Template:
 
         out += """
 <div class="row-fluid">
-    <div class="span12 well bskbasketheader bskbasketheadertitle">
+    <div class="col-md-12 well bskbasketheader bskbasketheadertitle">
         <strong>
             %(header_label)s
         </strong>
@@ -2354,7 +2354,7 @@ class Template:
 
     <div class="row-fluid well" %(optional_colspan)s>
       <!-- bskbasketheadertitle -->
-      <div class="span4">
+      <div class="col-md-4">
         <strong>
           %(name)s
         </strong>
@@ -2365,7 +2365,7 @@ class Template:
       </div>
 
       <!-- bskbasketheaderoptions -->
-      <div class="span5 offset3 pagination-right">
+      <div class="col-md-5 col-md-offset-3 pagination-right">
         %(add_ext_resource)s
         %(edit_basket)s
         %(delete_basket)s
@@ -2437,12 +2437,12 @@ class Template:
 
         out = """
         <div class="row-fluid well">
-            <div class="span4 bskbasketfootertitle">
+            <div class="col-md-4 bskbasketfootertitle">
                 <small>
                 %(display_public)s
                 </small>
             </div>
-            <div class="span5 offset3 pagination-right bskbasketfooteroptions">
+            <div class="col-md-5 col-md-offset-3 pagination-right bskbasketfooteroptions">
                 %(add_ext_resource)s
                 %(edit_basket)s
                 %(delete_basket)s
@@ -2644,19 +2644,19 @@ class Template:
         out = """
 
     <div class="row-fluid">
-      <div class="span1 bskcontentcount">
+      <div class="col-md-1 bskcontentcount">
         %(count)i.
       </div>
-      <div class="span11 bskcontentcol">
+      <div class="col-md-11 bskcontentcol">
         %(icon)s%(content)s
       </div>
     </div>
 
     <div class="row-fluid">
-      <div class="span1 bskcontentoptions">
+      <div class="col-md-1 bskcontentoptions">
         %(moveup)s%(movedown)s
       </div>
-      <div class="span4 moreinfo">"""
+      <div class="col-md-4 moreinfo">"""
 
         if item[0] > 0:
             detailed_record = """<a class="moreinfo" href="%(siteurl)s/%(CFG_SITE_RECORD)s/%(recid)s">%(detailed_record_label)s</a>"""
@@ -2687,7 +2687,7 @@ class Template:
 
         out += """
       </div>
-      <div class="span5 offset2 pagination-right bskbasketheaderoptions">
+      <div class="col-md-5 col-md-offset-2 pagination-right bskbasketheaderoptions">
         %(copy)s
         &nbsp;
         %(move)s

--- a/invenio/legacy/webstyle/webdoc.py
+++ b/invenio/legacy/webstyle/webdoc.py
@@ -562,7 +562,7 @@ def get_webdoc_topics(sort_by='name', sc=0, limit=-1,
                                    '<span class="label pull-right">' +
                                    time.strftime('%Y-%m-%d', topic_item[1]) +
                                    '</span>' if sort_by == 'date' else
-                                   '<i class="icon-chevron-right pull-right"></i>'))
+                                   '<i class="glyphicon glyphicon-chevron-right pull-right"></i>'))
                                 for topic_item in topic[:limit]]) + \
             '</li></ul>'
 

--- a/invenio/legacy/webstyle/webdoc_webinterface.py
+++ b/invenio/legacy/webstyle/webdoc_webinterface.py
@@ -156,7 +156,7 @@ def display_webdoc_page(webdocname, categ="help", ln=CFG_SITE_LANG, req=None):
                      'hacking': '<a class="navtrail" href="/help/hacking%s">%s</a>' % \
                      (ln_link, _("Hacking Invenio"))}
         body = '<div class="container" ><div class="row">' + \
-               '<div  class="span8"><h5>' + \
+               '<div  class="col-md-8"><h5>' + \
               _('Table of contents of the %(x_category)s pages.',
                 x_category=_(categ))
         if categ != 'help':
@@ -167,7 +167,7 @@ def display_webdoc_page(webdocname, categ="help", ln=CFG_SITE_LANG, req=None):
 
         body += '</h5>' + get_webdoc_topics(sort_by='name', sc=1,
                                           categ=[categ], ln=ln) + \
-                '</div><div  class="span4">' + \
+                '</div><div  class="col-md-4">' + \
                 '<h5>'+_("Latest modifications:") + '</h5>' + \
                 get_webdoc_topics(sort_by='date', sc=0, limit=5,
                                   categ=[categ], ln=ln)+'</div></div></div>'

--- a/invenio/modules/access/templates/access/admin_actionarea.html
+++ b/invenio/modules/access/templates/access/admin_actionarea.html
@@ -44,7 +44,7 @@ $(document).ready(function() {
 <ul class="nav nav-pills">
   <li>
     <a rel="tooltip" title="{{ _('go here to add a new role.') }}" href="{{ url_for('.addrole') }}">
-      <i class="icon-pencil"></i> {{ _("Create new role") }}
+      <i class="glyphicon glyphicon-pencil"></i> {{ _("Create new role") }}
     </a>
   </li>
 {#  <li><button class="btn" data-toggle="collapse" data-target="#filter" href="#filter">{{ _("Toggle Filter") }}</button></li>#}

--- a/invenio/modules/access/templates/access/admin_rolearea.html
+++ b/invenio/modules/access/templates/access/admin_rolearea.html
@@ -43,7 +43,7 @@ $(document).ready(function() {
 <ul class="nav nav-pills">
   <li>
     <a rel="tooltip" title="{{ _('go here to add a new role.') }}" href="{{ url_for('.addrole') }}">
-      <i class="icon-pencil"></i> {{ _("Create new role") }}
+      <i class="glyphicon glyphicon-pencil"></i> {{ _("Create new role") }}
     </a>
   </li>
 {#  <li><button class="btn" data-toggle="collapse" data-target="#filter" href="#filter">{{ _("Toggle Filter") }}</button></li>#}

--- a/invenio/modules/access/templates/access/admin_showroledetails.html
+++ b/invenio/modules/access/templates/access/admin_showroledetails.html
@@ -35,19 +35,19 @@ $(document).ready(function() {
 <ul class="nav nav-pills">
   <li>
     <a rel="tooltip" title="{{ _('go here to add a new role.') }}" href="{{ url_for('.addrole') }}">
-      <i class="icon-pencil"></i> {{ _("Create new role") }}
+      <i class="glyphicon glyphicon-pencil"></i> {{ _("Create new role") }}
     </a>
   </li>
   <li>
     <a rel="tooltip" title="{{ _('connect a user to role %s.') % role.name }}" href="{{ url_for('.adduserrole', id_role=role.id) }}">
-      <i class="icon-user"></i> {{ _("Connect user") }}
+      <i class="glyphicon glyphicon-user"></i> {{ _("Connect user") }}
     </a>
   </li>
 {#  <li><button class="btn" data-toggle="collapse" data-target="#filter" href="#filter">{{ _("Toggle Filter") }}</button></li>#}
 </ul>
 
 <div class="row">
-<div class="span4">
+<div class="col-md-4">
 <h3>{{ _('Role details') }}</h3>
 <dl>
   <dt>{{ _('Id') }}</dt>
@@ -60,7 +60,7 @@ $(document).ready(function() {
   <dd><pre>{{ role.firerole_def_src }}</pre></dd>
 </dl>
 </div>
-<div class="span4">
+<div class="col-md-4">
 <h3>{{ _('Users') }}</h3>
 {%- if role.users -%}
 <table class="table">
@@ -72,7 +72,7 @@ $(document).ready(function() {
     </a>
     </td><td>
     <a rel="tooltip" title="{{ _('disconnect from role') }}" class="pull-right" href="{{ url_for('.deleteuserrole', id_role=role.id, id_user=u.user.id) }}">
-      <i class="icon-remove-sign"></i>
+      <i class="glyphicon glyphicon-remove-sign"></i>
     </a>
     </td>
   </tr>
@@ -81,24 +81,24 @@ $(document).ready(function() {
 {%- endif -%}
 </div>
 
-<div class="span4">
+<div class="col-md-4">
 <h3>{{ _('Actions') }}</h3>
 {%- if role.authorizations -%}
 <div class="accordion">
   {%- for action, authorizations in role.authorizations|groupby('action') -%}
-  <div class="accordion-group">
-    <div class="accordion-heading">
-    <div class="accordion-toggle" data-toggle="collapse" data-target="#auths{{ action.id }}">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+    <div data-toggle="collapse" data-target="#auths{{ action.id }}">
     <a href="{{ url_for('.showactiondetails', id_action=action.id) }}">
       {{ action.name }}
     </a>
     <a rel="tooltip" title="{{ _('disconnect action with all arguments from role') }}" class="pull-right" href="{{ url_for('.deleteauthorization', id_role=role.id, id_action=action.id) }}">
-      <i class="icon-remove-sign"></i>
+      <i class="glyphicon glyphicon-remove-sign"></i>
     </a>
     </div>
     </div>
     {%- if authorizations and authorizations[0].argument -%}
-    <div id="auths{{ action.id }}" class="collapse in accordion-body">
+    <div id="auths{{ action.id }}" class="collapse in panel-collapse">
     <table class="table">
     {%- for i, auths in authorizations|groupby('argumentlistid') -%}
       {%- if loop.first -%}
@@ -111,7 +111,7 @@ $(document).ready(function() {
       </td>
       <td>
         <a rel="tooltip" title="{{ _('disconnect argument list from role') }}" class="pull-right" href="{{ url_for('.deleteauthorization', id_role=role.id, id_action=action.id, argumentlistid=i) }}">
-          <i class="icon-remove-sign"></i>
+          <i class="glyphicon glyphicon-remove-sign"></i>
         </a>
       </td>
       </tr>

--- a/invenio/modules/access/templates/access/admin_userarea.html
+++ b/invenio/modules/access/templates/access/admin_userarea.html
@@ -42,7 +42,7 @@ $(document).ready(function() {
 <ul class="nav nav-pills">
   <li>
     <a rel="tooltip" title="{{ _('go here to add a new role.') }}" href="{{ url_for('.addrole') }}">
-      <i class="icon-pencil"></i> {{ _("Create new role") }}
+      <i class="glyphicon glyphicon-pencil"></i> {{ _("Create new role") }}
     </a>
   </li>
 {#  <li><button class="btn" data-toggle="collapse" data-target="#filter" href="#filter">{{ _("Toggle Filter") }}</button></li>#}

--- a/invenio/modules/accounts/static/css/accounts/login.css
+++ b/invenio/modules/accounts/static/css/accounts/login.css
@@ -1,0 +1,34 @@
+.form-signin {
+  max-width: 330px;
+  padding: 15px;
+  margin: 0 auto;
+}
+.form-signin .form-signin-heading,
+.form-signin .checkbox {
+  margin-bottom: 10px;
+}
+.form-signin .checkbox {
+  font-weight: normal;
+}
+.form-signin .form-control {
+  position: relative;
+  font-size: 16px;
+  height: auto;
+  padding: 10px;
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
+}
+.form-signin .form-control:focus {
+  z-index: 2;
+}
+.form-signin input[type="text"] {
+  margin-bottom: -1px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.form-signin input[type="password"] {
+  margin-bottom: 10px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/invenio/modules/accounts/templates/accounts/index.html
+++ b/invenio/modules/accounts/templates/accounts/index.html
@@ -28,6 +28,7 @@
     <input placeholder="{{ _('Filter widgets') }}"
            type="text"
            name="widget"
+           class="form-control"
            autofocus />
   </small>
   </h1>
@@ -41,24 +42,24 @@
 
 <div class="container">
   <div class="row">
-   <div class="span12">
-    <ul id="widgets" class="thumbnails">
-      <li id="leftColumn" class="widgetColumn">
-        <ul id="widgetsLeft" class="connectedWidgets">
+   <div class="col-md-12">
+    <ul id="widgets" class="list-unstyled">
+      <li id="leftColumn" class="widgetColumn col-md-4">
+        <ul id="widgetsLeft" class="connectedWidgets list-unstyled">
           {%- for p in plugins[0] -%}
             {{display_widget(p)}}
           {%- endfor -%}
         </ul>
       </li>
-      <li id="middleColumn" class="widgetColumn">
-        <ul id="widgetsMiddle" class="connectedWidgets">
+      <li id="middleColumn" class="widgetColumn col-md-4">
+        <ul id="widgetsMiddle" class="connectedWidgets list-unstyled">
           {%- for p in plugins[1] -%}
             {{display_widget(p)}}
           {%- endfor -%}
         </ul>
       </li>
-      <li id="rightColumn" class="widgetColumn">
-        <ul id="widgetsRight" class="connectedWidgets">
+      <li id="rightColumn" class="widgetColumn col-md-4">
+        <ul id="widgetsRight" class="connectedWidgets list-unstyled">
           {%- for p in plugins[2] -%}
             {{display_widget(p)}}
           {%- endfor -%}
@@ -71,11 +72,11 @@
   <hr/>
 
   <div class="row">
-    <div class="span12" id="closed-list-bar">
+    <div class="col-md-12" id="closed-list-bar">
       <h5>{{ _('Closed Widgets') }} <small>{{ _('can be re-opened by clicking on folloing button(s)') }}</small></h5>
       <ul id="closed-list">
       {%- for p in closed_plugins -%}
-        <li id="{{ p.name}}" class="btn display-widget">{{p.title}} <i class="icon-plus"></i></li>
+        <li id="{{ p.name}}" class="btn display-widget">{{p.title}} <i class="glyphicon glyphicon-plus"></i></li>
       {%- endfor -%}
       </ul>
     </div>
@@ -94,11 +95,6 @@
 
 .thumbnail {
   cursor: move;
-}
-
-.thumbnails > li {
-  float: left;
-  width: 30%;
 }
 
 .thumbnails li {
@@ -156,7 +152,7 @@
   function addToClosedList(title, id) {
     $("#closed-list").append("<li id='" + id +
         "' class='btn display-widget'>" +
-        title + "<i class='icon-plus'></i></li>");
+        title + "<i class='glyphicon glyphicon-plus'></i></li>");
     bindDisplayWidgetEvents();
   }
 

--- a/invenio/modules/accounts/templates/accounts/login.html
+++ b/invenio/modules/accounts/templates/accounts/login.html
@@ -23,10 +23,12 @@
                            + config.CFG_OAUTH1_PROVIDERS * config.CFG_OAUTH1_AUTHENTICATION
                            + config.CFG_OAUTH2_PROVIDERS * config.CFG_OAUTH2_AUTHENTICATION %}
 
+{%- css url_for('webaccount.static', filename='css/accounts/login.css'), '10-login' -%}
+
 {% block body %}
 
 <div class="row">
-  <div class="span8 offset2">
+  <div class="col-md-8 col-md-offset-2">
     <p class="lead text-center">{{ _("If you already have an account, please login using the form below.") }}</p>
     <p class="text-center">{{ _("If you don't own an account yet, please %(x_url_open)sregister")|format(
       x_url_open='<a href="'+url_for('webaccount.register')+'">')|safe }}
@@ -37,17 +39,19 @@
 </div>
 
 <div class="row">
-  <div class="span4 offset{{ '2' if activated_providers else '4' }}">
+  <div class="col-md-4 col-md-offset-{{ '2' if activated_providers else '4' }}">
     <legend>{{ _('Please Sign In') }}</legend>
-    <form action="{{ url_for('webaccount.login') }}" method="POST">
+    <form class="form-signin" action="{{ url_for('webaccount.login') }}" method="POST">
+      <div class="form-group">
     {{ form.referer }}
     {{ form.login_method }}
-    {{ form.nickname(placeholder=_('Username or email'), class_="span4") }}
-    {{ form.password(placeholder=_('Password'), class_="span4") }}
-    <label class="checkbox">
-      {{ form.remember(class_="checkbox") }} {{ form.remember.label.text }}
-    </label>
-    {{ form.submit(class_="btn btn-info btn-block") }}
+    {{ form.nickname(placeholder=_('Username or email'), class_="form-control", type="text") }}
+    {{ form.password(placeholder=_('Password'), class_="form-control", type="password") }}
+      </div>
+      <label class="checkbox">
+        {{ form.remember(class_="checkbox") }} {{ form.remember.label.text }}
+      </label>
+      {{ form.submit(class_="btn btn-info btn-block") }}
     </form>
     <p class="text-right">
       <a href="{{ url_for('webaccount.lost') }}">
@@ -141,7 +145,7 @@
                type="text" name="identifier" value=""
                placeholder="{{ label|format(provider=provider) }}">
         <button class="btn btn-info btn-block" type="submit">
-          {{ _('Continue') }}&nbsp;<i class="icon-chevron-right icon-white"></i>
+          {{ _('Continue') }}&nbsp;<i class="glyphicon glyphicon-chevron-right"></i>
         </button>
       </form>
     </div>
@@ -179,11 +183,11 @@
   border: none;
 }
 </style>
-    <div class="span1 hidden-phone" style="height: 200px; padding: 0px; display: block; float: left; width: 1px;
+    <div class="col-md-1 hidden-xs" style="height: 200px; padding: 0px; display: block; float: left; width: 1px;
     border-right: 1px solid #ccc;">&nbsp;</div>
 
 
-    <div class="span4">
+    <div class="col-md-4">
       <legend style="font-size: 90%;">{{ _('or Select Your Authentication Provider:') }}</legend>
 
       <ul class="auth_providers thumbnails">

--- a/invenio/modules/accounts/templates/accounts/register.html
+++ b/invenio/modules/accounts/templates/accounts/register.html
@@ -23,10 +23,10 @@
 {% block body %}
 <div class="container">
   <div class="row">
-    <div class="offset3 span6 well">
+    <div class="col-md-offset-3 col-md-6 well">
       <form class="form-horizontal" method="POST" action="{{ url_for('.register',) }}">
       {%- if state == 'success' %}
-        <legend>{{title}}<span class="pull-right"><i class="icon-ok"></i></span></legend>
+        <legend>{{title}}<span class="pull-right"><i class="glyphicon glyphicon-ok"></i></span></legend>
         {%- for m in messages %}
             <p>{{m}}</p>
         {%- endfor %}
@@ -34,9 +34,9 @@
         <fieldset>
           <legend>{{title}}<span class="pull-right">
           {%- if state -%}
-            <i class="icon-warning-sign"></i>
+            <i class="glyphicon glyphicon-warning-sign"></i>
           {%- else -%}
-            <i class="icon-edit"></i>
+            <i class="glyphicon glyphicon-edit"></i>
           {%- endif -%}
           </span></legend>
           {% if messages and state != 'success' %}
@@ -47,7 +47,7 @@
           </div>
           {% endif %}
           {% for field in form if field.name != 'submit' %}
-            {{render_field(field, show_description=True)}}
+            {{render_field(field, show_description=True, label_size=3, field_size=9)}}
           {% endfor %}
         </fieldset>
         {{form.submit(value="Sign up", class="btn btn-warning btn-large pull-right")}}

--- a/invenio/modules/accounts/templates/accounts/widget.html
+++ b/invenio/modules/accounts/templates/accounts/widget.html
@@ -1,12 +1,11 @@
 {% macro display_widget(p) %}
-<li id="{{ p.name}}" class="widget span4">
-  <div class="thumbnail">
-    <div class="caption">
-      <h4>
+<li id="{{ p.name}}" class="widget">
+  <div class="panel panel-default">
+    <div class="panel-heading">
       {%- if p.icon -%}
         <small><i
           style="margin-top: 0px;"
-          class="icon-{{ p.icon|safe }}"></i>&nbsp;
+          class="glyphicon glyphicon-{{ p.icon|safe }}"></i>&nbsp;
         </small>
       {%- endif -%}
 
@@ -18,16 +17,15 @@
       {%- endif -%}
       <small>
         {%- if p.edit -%}
-        &nbsp;<a class="edit" href="{{ p.edit|safe }}"><i class="icon-wrench"></i></a>
+        &nbsp;<a class="edit" href="{{ p.edit|safe }}"><i class="glyphicon glyphicon-wrench"></i></a>
         {%- endif -%}
         <span class="close hide">&nbsp;&times;</span>
       </small>
-      </h4>
-      <div style="
-        width: 90%;
-        min-height: 80px;">
-        {{ p.widget()|safe }}
-      </div>
+    </div>
+    <div class="panel-body" style="
+      width: 90%;
+      min-height: 80px;">
+      {{ p.widget()|safe }}
     </div>
   </div>
 </li>

--- a/invenio/modules/accounts/views.py
+++ b/invenio/modules/accounts/views.py
@@ -47,7 +47,8 @@ from invenio.utils.url import rewrite_to_secure_url
 #CFG_FULL_HTTPS = CFG_SITE_URL.lower().startswith("https://")
 
 blueprint = Blueprint('webaccount', __name__, url_prefix="/youraccount",
-                      template_folder='templates')
+                      template_folder='templates',
+                      static_folder='static')
 
 
 def update_login(nickname, password=None, remember_me=False):

--- a/invenio/modules/comments/templates/comments/add.html
+++ b/invenio/modules/comments/templates/comments/add.html
@@ -23,17 +23,18 @@
       style="{{ 'margin-bottom:0px;' if request.is_xhr }}"
       method="post" class="form-horizontal">
   <div class="{{ 'modal-body' if request.is_xhr }}">
-    {{ form.csrf_token }}
-    {{ render_field(form.in_reply_to_id_cmtRECORDCOMMENT) }}
-    {{ render_field(form.title) }}
-    {{ render_field(form.body) }}
+    <div class="col-sd-12 col-xs-12">
+      {{ form.csrf_token }}
+      {{ render_field(form.in_reply_to_id_cmtRECORDCOMMENT) }}
+      {{ render_field(form.title) }}
+      {{ render_field(form.body) }}
+    </div>
   </div>
   <div class="{{ 'modal-footer ' if request.is_xhr else 'form-actions'}}">
         <input type="submit" name="send_button" value="{{ _("Send") }}" class="btn btn-primary"/>
-
-      {%- if request.is_xhr -%}
-        <a class="btn" data-dismiss="modal">Close</a>
-      {%- endif -%}
+        {%- if request.is_xhr -%}
+          <a class="btn" data-dismiss="modal">Close</a>
+        {%- endif -%}
   </div>
 </form>
 {% endmacro %}
@@ -45,9 +46,13 @@
   {% endblock %}
 {%- else -%}
 
-  <div class="modal-header">
-    <a class="close" data-dismiss="modal">×</a>
-    <h3>{{ _('Write a comment') }}</h3>
+<div class="modal-dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3>{{ _('Write a comment') }}</h3>
+    </div>
+    {{ add_comment() }}
   </div>
-  {{ add_comment() }}
+</div>
 {%- endif -%}

--- a/invenio/modules/comments/templates/comments/add_review.html
+++ b/invenio/modules/comments/templates/comments/add_review.html
@@ -23,18 +23,19 @@
       style="{{ 'margin-bottom:0px;' if request.is_xhr }}"
       method="post" class="form-horizontal">
   <div class="{{ 'modal-body' if request.is_xhr }}">
-    {{ form.csrf_token }}
-    {{ render_field(form.in_reply_to_id_cmtRECORDCOMMENT) }}
-    {{ render_field(form.title) }}
-    {{ render_field(form.body) }}
-    {{ render_field(form.star_score) }}
+    <div class="col-sd-12 col-xs-12">
+      {{ form.csrf_token }}
+      {{ render_field(form.in_reply_to_id_cmtRECORDCOMMENT) }}
+      {{ render_field(form.title) }}
+      {{ render_field(form.body) }}
+      {{ render_field(form.star_score) }}
+    </div>
   </div>
   <div class="{{ 'modal-footer ' if request.is_xhr else 'form-actions'}}">
         <input type="submit" name="send_button" value="{{ _("Send") }}" class="btn btn-primary"/>
-
-      {%- if request.is_xhr -%}
-        <a class="btn" data-dismiss="modal">Close</a>
-      {%- endif -%}
+        {%- if request.is_xhr -%}
+          <a class="btn" data-dismiss="modal">Close</a>
+        {%- endif -%}
   </div>
 </form>
 {% endmacro %}
@@ -46,9 +47,13 @@
   {% endblock %}
 {%- else -%}
 
-  <div class="modal-header">
-    <a class="close" data-dismiss="modal">×</a>
-    <h3>{{ _('Write a comment') }}</h3>
+<div class="modal-dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3>{{ _('Write a comment') }}</h3>
+    </div>
+    {{ add_comment() }}
   </div>
-  {{ add_comment() }}
+</div>
 {%- endif -%}

--- a/invenio/modules/comments/templates/comments/comments.html
+++ b/invenio/modules/comments/templates/comments/comments.html
@@ -34,11 +34,11 @@
       {{ _("Comments") }}
       <small>
         {% if current_user.is_guest %}
-          <a class="btn pull-right" href="{{ url_for('webaccount.login', referer=request.url) }}">
+          <a class="btn btn-default pull-right" href="{{ url_for('webaccount.login', referer=request.url) }}">
         {% else %}
-          <a class="btn pull-right" data-toggle="modal" href="{{ url_for('comments.add_comment', recid=recid) }}">
+          <a class="btn btn-default pull-right" data-toggle="modal" href="{{ url_for('comments.add_comment', recid=recid) }}">
         {% endif %}
-            <i class="icon-pencil"></i> {{ _('write comment') }}
+            <i class="glyphicon glyphicon-pencil"></i> {{ _('write comment') }}
           </a>
       </small>
     </h4>
@@ -54,7 +54,7 @@
        data-toggle="collapse"
        data-target="#collapse-{{ c.id }}"
        href="{#{ url_for('comments.toggle', recid=recid, id=c.id) }#}">
-      <i class="icon-chevron-down"></i>
+      <i class="glyphicon glyphicon-chevron-down"></i>
     </a>
 
     <h4>
@@ -95,8 +95,8 @@
         <img src="/img/user-icon-1-16x16.gif" alt="avatar"/>
           {{ _('Guest') }}
         {%- endif -%} &nbsp;
-        - <i class="icon-time"></i> {{ c.date_creation }}
-        - <i class="icon-pencil"></i>
+        - <i class="glyphicon glyphicon-time"></i> {{ c.date_creation }}
+        - <i class="glyphicon glyphicon-pencil"></i>
         {% if current_user.is_guest %}
           <a href="{{ url_for('webaccount.login', referer=url_for('comments.add_comment', recid=recid, in_reply=c.id)) }}">
         {% else %}
@@ -104,28 +104,28 @@
         {% endif %}
             {{ _('reply') }}
           </a>
-        - <i class="icon-question-sign"></i> {{ _('Was it helpful?') }}
+        - <i class="glyphicon glyphicon-question-sign"></i> {{ _('Was it helpful?') }}
          <a href="{{ url_for('comments.vote', recid=recid, id=c.id, value=1,
             referer=request.url
           ) }}">
-          <i class="icon-thumbs-up"></i>
+          <i class="glyphicon glyphicon-thumbs-up"></i>
           {{ _('yes') }}
           </a> /
           <a href="{{ url_for('comments.vote', recid=recid, id=c.id, value=-1,
             referer=request.url
           ) }}">
-          <i class="icon-thumbs-down"></i>
+          <i class="glyphicon glyphicon-thumbs-down"></i>
           {{ _('no') }}
           </a>
         -
           <a href="{{ url_for('comments.report', recid=recid, id=c.id) }}">
-            <i class="icon-exclamation-sign"></i>
+            <i class="glyphicon glyphicon-exclamation-sign"></i>
             {{ _('report abuse') }}
           </a>
       </small>
     </blockquote>
     {%- if c.replies -%}
-    <ul class="unstyled" style="padding-left: 20px;">
+    <ul class="list-unstyled" style="padding-left: 20px;">
       {{ loop(c.replies) }}
     </ul>
     {%- endif -%}
@@ -143,7 +143,7 @@
   {% else %}
     <a class="btn pull-right" data-toggle="modal" href="{{ url_for('comments.add_comment', recid=recid) }}">
   {% endif %}
-      <i class="icon-pencil"></i> {{ _('write comment') }}
+      <i class="glyphicon glyphicon-pencil"></i> {{ _('write comment') }}
     </a>
 
   {%- else -%}
@@ -159,7 +159,7 @@
 
   <div class="alert">
   {%- set info_subs = _('%(open_tag)s Unsubscribe %(close_tag)s from this discussion. You will not receive any new comments by email.') % {
-    'open_tag': '<strong><a href="'+url_for('comments.unsubscribe', recid=recid)+'"><i class="icon-trash"></i>',
+    'open_tag': '<strong><a href="'+url_for('comments.unsubscribe', recid=recid)+'"><i class="glyphicon glyphicon-trash"></i>',
     'close_tag':'</a></strong>'} -%}
     {{ info_subs|safe }}
   </div>
@@ -168,7 +168,7 @@
 
   <div class="alert alert-info">
   {%- set info_subs = _('%(open_tag)s Subscribe %(close_tag)s to this discussion. You will then receive all new comments by email.') % {
-    'open_tag': '<strong><a href="'+url_for('comments.subscribe', recid=recid)+'"><i class="icon-envelope"></i>',
+    'open_tag': '<strong><a href="'+url_for('comments.subscribe', recid=recid)+'"><i class="glyphicon glyphicon-envelope"></i>',
     'close_tag':'</a></strong>'} -%}
     {{ info_subs|safe }}
   </div>

--- a/invenio/modules/comments/templates/comments/reviews.html
+++ b/invenio/modules/comments/templates/comments/reviews.html
@@ -30,11 +30,11 @@
       {{ _("Reviews") }}
       <small>
       {% if current_user.is_guest %}
-        <a class="btn pull-right" href="{{ url_for('webaccount.login', referer=request.url) }}">
+        <a class="btn btn-default pull-right" href="{{ url_for('webaccount.login', referer=request.url) }}">
       {% else %}
-        <a class="btn pull-right" data-toggle="modal" href="{{ url_for('comments.add_review', recid=recid) }}">
+        <a class="btn btn-default pull-right" data-toggle="modal" href="{{ url_for('comments.add_review', recid=recid) }}">
       {% endif %}
-          <i class="icon-pencil"></i> {{ _('write review') }}
+          <i class="glyphicon glyphicon-pencil"></i> {{ _('write review') }}
         </a>
 
       </small>
@@ -43,7 +43,7 @@
 
   {%- if comments -%}
 
-  <ul class="unstyled">
+  <ul class="list-unstyled">
   {%- for c in comments -%}
   <li name="{{ c.id }}">
     <div>
@@ -51,7 +51,7 @@
     {{ c.title }}
     <small>
        /
-      {{ ('<i class="icon-star"></i>'|safe) * (c.star_score) }}{{ ('<i class="icon-star-empty"></i>'|safe) * ((5-c.star_score)) }} &nbsp;
+      {{ ('<i class="glyphicon glyphicon-star"></i>'|safe) * (c.star_score) }}{{ ('<i class="glyphicon glyphicon-star-empty"></i>'|safe) * ((5-c.star_score)) }} &nbsp;
       {%- if c.nb_votes_total > 0 -%}
         {%- set votes = c.nb_votes_yes-(c.nb_votes_total-c.nb_votes_yes) -%}
         {%- if votes > 0 -%}
@@ -78,25 +78,25 @@
         <img src="/img/user-icon-1-16x16.gif" alt="avatar"/>
           {{ _('Guest') }}
         {%- endif -%} &nbsp;
-        - <i class="icon-time"></i> {{ c.date_creation }}
-        - <i class="icon-question-sign"></i> {{ _('Was it helpful?') }}
+        - <i class="glyphicon glyphicon-time"></i> {{ c.date_creation }}
+        - <i class="glyphicon glyphicon-question-sign"></i> {{ _('Was it helpful?') }}
           <a href="{{ url_for('comments.vote', recid=recid, id=c.id, value=1,
             referer=request.url
           ) }}">
-          <i class="icon-thumbs-up"></i>
+          <i class="glyphicon glyphicon-thumbs-up"></i>
           {{ _('yes') }}
           </a> /
           <a href="{{ url_for('comments.vote', recid=recid, id=c.id, value=-1,
             referer=request.url
           ) }}">
-          <i class="icon-thumbs-down"></i>
+          <i class="glyphicon glyphicon-thumbs-down"></i>
           {{ _('no') }}
           </a>
           -
           <a href="{{ url_for('comments.report', recid=recid, id=c.id,
             referer=request.url
           ) }}">
-            <i class="icon-exclamation-sign"></i>
+            <i class="glyphicon glyphicon-exclamation-sign"></i>
             {{ _('report abuse') }}
           </a>
       </small>
@@ -108,11 +108,11 @@
 
   {% if current_user.is_guest %}
         <a class="btn pull-right" href="{{ url_for('webaccount.login', referer=request.url) }}">
-          <i class="icon-pencil"></i> {{ _('write review') }}
+          <i class="glyphicon glyphicon-pencil"></i> {{ _('write review') }}
         </a>
       {% else %}
         <a class="btn pull-right" data-toggle="modal" href="{{ url_for('comments.add_review', recid=recid) }}">
-          <i class="icon-pencil"></i> {{ _('write review') }}
+          <i class="glyphicon glyphicon-pencil"></i> {{ _('write review') }}
         </a>
       {% endif %}
   {%- else -%}

--- a/invenio/modules/deposit/field_widgets.py
+++ b/invenio/modules/deposit/field_widgets.py
@@ -26,11 +26,8 @@ from invenio.ext.template import render_template_to_string
 
 def date_widget(field, **kwargs):
     field_id = kwargs.pop('id', field.id)
-    html = [u'<input class="datepicker" %s type="text">'
+    html = [u'<input class="datepicker form-control" %s type="text">'
             % html_params(id=field_id, name=field_id, value=field.data or '')]
-    field_class = kwargs.pop('class', '') or kwargs.pop('class_', '')
-    kwargs['class'] = u'datepicker %s' % field_class
-    kwargs['class'] = u'date %s' % field_class
     return HTMLString(u''.join(html))
 
 
@@ -115,9 +112,9 @@ def dropbox_widget(field, **kwargs):
                 </tbody>\
             </table>\
             <a class="btn btn-success disabled" id="uploadfiles"> \
-                <i class="icon-upload icon-white"></i> Start upload</a>\
+                <i class="glyphicon glyphicon-upload"></i> Start upload</a>\
             <a class="btn btn-danger" id="stopupload" style="display:none;">\
-                <i class="icon-stop icon-white"></i> Cancel upload</a>\
+                <i class="glyphicon glyphicon-stop"></i> Cancel upload</a>\
             <span id="upload_speed" class="pull-right"></span>\
             <div id="upload-errors"></div>\
         </div>' % html_params(id=field_id)]
@@ -159,7 +156,7 @@ class ButtonWidget(object):
 
         state = ""
         if field._value():
-            state = '<span class="text-success"> <i class="icon-ok"></i></span>'
+            state = '<span class="text-success"> <i class="glyphicon glyphicon-ok"></i></span>'
 
         return HTMLString(u'<button %s>%s%s</button><span %s>%s</span>' % (
             html_params(name=field.name, **params),
@@ -251,8 +248,8 @@ class DynamicItemWidget(ListItemWidget):
         <div><span>"buttons</span>:field</div>
     """
     def __init__(self, **kwargs):
-        self.icon_reorder = kwargs.pop('icon_reorder', 'icon-reorder')
-        self.icon_remove = kwargs.pop('icon_remove', 'icon-remove-sign')
+        self.icon_reorder = kwargs.pop('icon_reorder', 'glyphicon glyphicon-move')
+        self.icon_remove = kwargs.pop('icon_remove', 'glyphicon glyphicon-remove')
         defaults = dict(
             html_tag='div',
             with_label=True,
@@ -261,20 +258,18 @@ class DynamicItemWidget(ListItemWidget):
         super(DynamicItemWidget, self).__init__(**defaults)
 
     def _sort_button(self):
-        return """<a class="sort-element muted sortlink iconlink" rel="tooltip" title="Drag to reorder"><i class="%s icon-large"></i></a>""" % self.icon_reorder
+        return """<a class="sort-element text-muted sortlink iconlink input-group-addon" rel="tooltip" title="Drag to reorder"><i class="%s"></i></a>""" % self.icon_reorder
 
     def _remove_button(self):
-        return """<a class="remove-element muted iconlink" rel="tooltip" title="Click to remove"><i class="%s icon-large"></i></a>""" % self.icon_remove
+        return """<a class="remove-element text-muted iconlink input-group-addon" rel="tooltip" title="Click to remove"><i class="%s"></i></a>""" % self.icon_remove
 
     def render_subfield(self, subfield, **kwargs):
         html = []
         # Button
-        html.append("<span %s>%s</span>" % (
-            html_params(class_='pull-right'),
-            self._sort_button() + self._remove_button()
-        ))
-        # Field
+        html.append(self._sort_button())
         html.append(subfield())
+        html.append(self._remove_button())
+
         return ''.join(html)
 
     def __call__(self, subfield, **kwargs):
@@ -286,7 +281,8 @@ class DynamicItemWidget(ListItemWidget):
         elif subfield.name.endswith('__input__'):
             kwargs['class_'] = kwargs.get('class_', '') + ' input-element'
         else:
-            kwargs['class_'] = kwargs.get('class_', '') + ' field-list-element'
+            # for deposit form
+            kwargs['class_'] = kwargs.get('class_', '') + ' field-list-element input-group'
         return super(DynamicItemWidget, self).__call__(subfield, **kwargs)
 
 
@@ -300,38 +296,11 @@ class TagItemWidget(DynamicItemWidget):
         defaults = dict(
             html_tag='li',
             with_label=False,
-            class_="alert alert-info tag"
+            class_="tag"
         )
         defaults.update(kwargs)
 
         super(TagItemWidget, self).__init__(**defaults)
-
-    def render_subfield(self, subfield, **kwargs):
-        return subfield()
-
-    def open_tag(self, subfield, **kwargs):
-        if self.html_tag:
-            if subfield.name.endswith('__input__'):
-                return '<%s>' % self.html_tag
-            else:
-                ctx = {}
-                if(isinstance(subfield.data, basestring)):
-                    ctx['value'] = subfield.data
-                elif subfield.data:
-                    ctx.update(subfield.data)
-
-                return '<%s %s><button type="button" class="close remove-element" data-dismiss="alert">&times;</button><span class="tag-title">%s</span>' % (
-                    self.html_tag,
-                    html_params(
-                        class_=self.class_ + ' ' + kwargs.get('class_', '')
-                    ),
-                    render_template_to_string(
-                        self.template,
-                        _from_string=True,
-                        **ctx
-                    )
-                )
-        return ''
 
 
 #
@@ -404,7 +373,7 @@ class DynamicListWidget(ExtendedListWidget):
     for each item to sort and remove the item.
     """
     item_widget = DynamicItemWidget()
-    icon_add = "icon-plus"
+    icon_add = "glyphicon glyphicon-plus"
 
     def __init__(self, **kwargs):
         self.icon_add = kwargs.pop('icon_add', self.icon_add)
@@ -418,7 +387,13 @@ class DynamicListWidget(ExtendedListWidget):
 
     def _add_button(self, field):
         label = getattr(field, 'add_label', None) or "Add %s" % field.label.text
-        return """<div><span class="pull-right"><a class="add-element"><i class="%s"></i> %s</a></span></div>""" % (self.icon_add, label)
+        return """<div>
+                    <span class="pull-right">
+                        <a class="add-element">
+                            <i class="%s"></i> %s
+                        </a>
+                    </span>
+                </div>""" % (self.icon_add, label)
 
     def item_kwargs(self, field, subfield):
         return {'empty_index': field.empty_index}
@@ -450,7 +425,7 @@ class TagListWidget(DynamicListWidget):
         self.template = kwargs.pop('template', '{{value}}')
         defaults = dict(
             html_tag='ul',
-            class_='dynamic-field-list unstyled',
+            class_='list-unstyled',
             item_widget=TagItemWidget(
                 template=self.template
             )
@@ -499,7 +474,7 @@ class BigIconRadioInput(RadioInput):
         html = super(BigIconRadioInput, self).__call__(field, **kwargs)
         icon = self.choices_icons.get(field._value(), '')
         if icon:
-            html = """<i class="icon-%s icon-2x"></i><br />%s</br>%s""" % (
+            html = """<i class="glyphicon glyphicon-%s icon-2x"></i><br />%s</br>%s""" % (
                 icon, field.label.text, html
             )
         return html
@@ -513,7 +488,7 @@ class InlineListWidget(object):
         kwargs.setdefault('id', field.id)
         html = [u'<ul class="inline">']
         for subfield in field:
-            html.append(u'<li class="span1"><label>%s</label></li>' % (subfield()))
+            html.append(u'<li class="col-md-1"><label>%s</label></li>' % (subfield()))
         html.append(u'</ul>')
         return HTMLString(u''.join(html))
 

--- a/invenio/modules/deposit/fields/abstract.py
+++ b/invenio/modules/deposit/fields/abstract.py
@@ -27,8 +27,9 @@ __all__ = ['AbstractField']
 class AbstractField(WebDepositField, TextAreaField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-pencil',
-            export_key='abstract.summary'
+            icon='pencil',
+            export_key='abstract.summary',
+            widget_classes='form-control'
         )
         defaults.update(kwargs)
         super(AbstractField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/author.py
+++ b/invenio/modules/deposit/fields/author.py
@@ -27,9 +27,10 @@ __all__ = ['AuthorField']
 class AuthorField(WebDepositField, TextField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-user',
+            icon='user',
             export_key='authors[0].full_name',
-            autocomplete=orcid_authors
+            autocomplete=orcid_authors,
+            widget_classes="form-control"
         )
         defaults.update(kwargs)
         super(AuthorField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/date.py
+++ b/invenio/modules/deposit/fields/date.py
@@ -28,8 +28,9 @@ __all__ = ['Date']
 class Date(WebDepositField, DateField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-calendar',
-            validators=[optional()]
+            icon='calendar',
+            validators=[optional()],
+            widget_classes="form-control"
         )
         defaults.update(kwargs)
         super(Date, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/doi.py
+++ b/invenio/modules/deposit/fields/doi.py
@@ -39,7 +39,7 @@ def missing_doi_warning(dummy_form, field, dummy_submit=False):
 class DOIField(WebDepositField, TextField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-barcode',
+            icon='barcode',
             validators=[
                 doi_syntax_validator,
             ],
@@ -52,6 +52,7 @@ class DOIField(WebDepositField, TextField):
                 datacite_lookup(display_info=True),
             ],
             placeholder="e.g. 10.1234/foo.bar...",
+            widget_classes="form-control"
         )
         defaults.update(kwargs)
         super(DOIField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/file_upload.py
+++ b/invenio/modules/deposit/fields/file_upload.py
@@ -25,6 +25,6 @@ __all__ = ['FileUploadField']
 
 class FileUploadField(WebDepositField, FileField):
     def __init__(self, **kwargs):
-        defaults = dict(icon='icon-upload', export_key=False)
+        defaults = dict(icon='upload', export_key=False)
         defaults.update(kwargs)
         super(FileUploadField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/issn.py
+++ b/invenio/modules/deposit/fields/issn.py
@@ -26,8 +26,9 @@ __all__ = ['ISSNField']
 class ISSNField(WebDepositField, TextField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-barcode',
+            icon='barcode',
             export_key='issn',
+            widget_classes="form-control",
             #validators=[sherpa_romeo_issn_validate] #FIXME
         )
         defaults.update(kwargs)

--- a/invenio/modules/deposit/fields/journal.py
+++ b/invenio/modules/deposit/fields/journal.py
@@ -28,9 +28,10 @@ __all__ = ['JournalField']
 class JournalField(WebDepositField, TextField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-book',
+            icon='book',
             processors=[sherpa_romeo_journal_process],
             autocomplete=sherpa_romeo_journals,
+            widget_classes="form-control",
         )
         defaults.update(kwargs)
         super(JournalField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/keywords.py
+++ b/invenio/modules/deposit/fields/keywords.py
@@ -27,7 +27,8 @@ class KeywordsField(WebDepositField, TextField):
 
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-tags',
+            icon='tags',
+            widget_classes="form-control"
             #validators=[sherpa_romeo_journal_validate], #FIXME
             #autocomplete=sherpa_romeo_journals,
         )

--- a/invenio/modules/deposit/fields/language.py
+++ b/invenio/modules/deposit/fields/language.py
@@ -26,8 +26,9 @@ __all__ = ['LanguageField']
 
 class LanguageField(WebDepositField, SelectField):
     def __init__(self, **kwargs):
-        defaults = dict(icon='icon-flag',
+        defaults = dict(icon='flag',
                         export_key='language',
-                        validators=[optional()])
+                        validators=[optional()],
+                        widget_classes="form-control")
         defaults.update(kwargs)
         super(LanguageField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/notes.py
+++ b/invenio/modules/deposit/fields/notes.py
@@ -26,7 +26,8 @@ __all__ = ['NotesField']
 class NotesField(WebDepositField, TextAreaField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-list',
+            icon='list',
+            widget_classes="form-control"
         )
         defaults.update(kwargs)
         super(NotesField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/pages_number.py
+++ b/invenio/modules/deposit/fields/pages_number.py
@@ -27,7 +27,8 @@ __all__ = ['PagesNumberField']
 class PagesNumberField(WebDepositField, TextField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-th',
+            icon='th',
+            widget_classes="form-control"
             #FIXMEvalidators=[number_validate(error_message='Pages must be a number!')] #FIXME
         )
         defaults.update(kwargs)

--- a/invenio/modules/deposit/fields/publisher.py
+++ b/invenio/modules/deposit/fields/publisher.py
@@ -28,9 +28,10 @@ __all__ = ['PublisherField']
 class PublisherField(WebDepositField, TextField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-certificate',
+            icon='certificate',
             processors=[sherpa_romeo_publisher_process],
-            autocomplete=sherpa_romeo_publishers
+            autocomplete=sherpa_romeo_publishers,
+            widget_classes="form-control"
         )
         defaults.update(kwargs)
         super(PublisherField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/record_id.py
+++ b/invenio/modules/deposit/fields/record_id.py
@@ -29,9 +29,10 @@ class RecordIDField(WebDepositField, TextField):
 
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-barcode',
+            icon='barcode',
             export_key='recid',
-            processors=[record_id_process]
+            processors=[record_id_process],
+            widget_classes="form-control"
         )
         defaults.update(kwargs)
         super(RecordIDField, self).__init__(**defaults)

--- a/invenio/modules/deposit/fields/title.py
+++ b/invenio/modules/deposit/fields/title.py
@@ -37,8 +37,9 @@ def validate_title(form, field):
 class TitleField(WebDepositField, TextField):
     def __init__(self, **kwargs):
         defaults = dict(
-            icon='icon-book',
+            icon='book',
             export_key='title.title',
+            widget_classes="form-control"
             #FIXMEvalidators=[validate_title]
         )
         defaults.update(kwargs)

--- a/invenio/modules/deposit/forms/article.py
+++ b/invenio/modules/deposit/forms/article.py
@@ -33,13 +33,15 @@ def keywords_autocomplete(form, field, term, limit=50):
 
 
 class AuthorForm(WebDepositForm):
+
     name = fields.TextField(
         placeholder="Family name, First name",
-        widget_classes='span3',
+        widget_classes='form-control right-not-rounded',
     )
+
     affiliation = fields.TextField(
         placeholder="Affiliation",
-        widget_classes='span2',
+        widget_classes='form-control left-not-rounded',
     )
 
 
@@ -54,26 +56,11 @@ class ArticleForm(WebDepositForm):
     issn = fields.ISSNField(label=_('ISSN'), export_key='issn')
     title = fields.TitleField(label=_('Document Title'),
                               export_key='title.title')
-    authors = fields.DynamicFieldList(
-        fields.FormField(
-            AuthorForm,
-            widget=ExtendedListWidget(
-                item_widget=ListItemWidget(with_label=False),
-                class_='inline',
-            ),
-        ),
-        label='Authors',
-        add_label='Add another author',
-        icon='icon-user',
-        widget_classes='',
-        min_entries=1,
-        export_key='authors'
-    )
 
     abstract = fields.AbstractField(
         label=_('Abstract'),
         export_key='abstract.summary',
-        widget=ckeditor_widget
+        widget=ckeditor_widget,
     )
     pagesnum = fields.PagesNumberField(label=_('Number of Pages'))
     languages = [("en", _("English")),
@@ -95,29 +82,33 @@ class ArticleForm(WebDepositForm):
     language = fields.LanguageField(label=_('Language'), choices=languages)
     date = fields.Date(label=_('Date of Document'), widget=date_widget,
                        export_key='imprint.date')
+
     authors = fields.DynamicFieldList(
         fields.FormField(
             AuthorForm,
             widget=ExtendedListWidget(
-                item_widget=ListItemWidget(with_label=False),
-                class_='inline',
+                item_widget=ListItemWidget(with_label=False, class_="col-sm-6 col-xs-6 no-padding"),
+                class_='collection-item list-unstyled',
             ),
         ),
         label='Authors',
         add_label='Add another author',
-        icon='icon-user',
-        widget_classes='',
+        icon='user',
         min_entries=1,
         export_key='authors'
     )
+
     keywords = fields.DynamicFieldList(
         fields.TextField(
             placeholder="Start typing a keyword...",
             autocomplete=keywords_autocomplete,
-            widget=TagInput()
+            widget_classes="form-control",
         ),
-        widget=TagListWidget(template="{{value}}"),
-        icon='icon-tags',
+        label='Keywords',
+        add_label='Add another keyword',
+        icon='tags',
+        min_entries=1,
+        export_key='keywords'
     )
     notes = fields.NotesField(label=_('Notes'), export_key='comment')
     plupload_file = fields.FileUploadField(widget=plupload_widget, label="")

--- a/invenio/modules/deposit/forms/preprint.py
+++ b/invenio/modules/deposit/forms/preprint.py
@@ -30,11 +30,11 @@ __all__ = ['PreprintForm']
 
 class PreprintForm(Form):
 
-    author = fields.AuthorField(label=_('Author'), validators=[Required()])
+    author = fields.AuthorField(label=_('Author'), validators=[Required()], widget_classes="form-control")
     subject_category = fields.TitleField(label=_('Subject category'),
                                                 validators=[Required()])
     note = fields.NotesField(label=_('Note'))
-    institution = fields.TextField(label=_('Institution'))
+    institution = fields.TextField(label=_('Institution'), widget_classes="form-control")
     languages = [("en", _("English")),
                  ("fre", _("French")),
                  ("ger", _("German")),

--- a/invenio/modules/deposit/forms/thesis.py
+++ b/invenio/modules/deposit/forms/thesis.py
@@ -34,7 +34,7 @@ class ThesisForm(Form):
                               validators=[Required()])
     subtitle = fields.TitleField(label=_('Original Thesis Subtitle'),
                                  export_key='title.subtitle')
-    author = fields.AuthorField(label=_('Author'),)
+    author = fields.AuthorField(label=_('Author'))
     supervisor = fields.AuthorField(label=_('Thesis Supervisor'))
     abstract = fields.AbstractField(label=_('Abstract'))
 
@@ -60,7 +60,8 @@ class ThesisForm(Form):
 
     funded_choices = [("yes", _("Yes")), ("no", _("No"))]
     funded = fields.SelectField(label=_("Has your thesis been funded by the CERN Doctoral Student Program?"),
-                                choices=funded_choices)
+                                choices=funded_choices,
+                                widget_classes="form-control")
 
     file_field = fields.FileUploadField(widget=plupload_widget)
     submit = fields.SubmitField(label=_('Submit Thesis'), widget=bootstrap_submit)

--- a/invenio/modules/deposit/static/js/deposit/form.js
+++ b/invenio/modules/deposit/static/js/deposit/form.js
@@ -713,9 +713,9 @@ function webdeposit_init_plupload(max_size, selector, save_url, url, delete_url,
         $('#upload-errors').hide();
         if (err.file){
             $('#' + err.file.id + " .progress").removeClass("progress-striped").addClass("progress-danger");
-            $('#upload-errors').append('<div class="alert alert-error"><strong>Error:</strong> Could not upload ' + err.file.name +" due to " + message + "</div>");
+            $('#upload-errors').append('<div class="alert alert-danger"><strong>Error:</strong> Could not upload ' + err.file.name +" due to " + message + "</div>");
         } else {
-            $('#upload-errors').append('<div class="alert alert-error"><strong>Error:</strong> ' + message + "</div>");
+            $('#upload-errors').append('<div class="alert alert-danger"><strong>Error:</strong> ' + message + "</div>");
         }
         $('#upload-errors').show('fast');
         $('#uploadfiles').addClass("disabled");
@@ -1248,6 +1248,7 @@ $.fn.fieldlist = function(opts) {
         // Remove class
         new_element.removeClass(options.empty_cssclass);
         new_element.addClass(options.element_css_class);
+        new_element.addClass("input-group");
         // Pre-populate field values
         update_element_values(new_element, data, field_prefix_index);
         // Update ids

--- a/invenio/modules/deposit/static/js/deposit/templates.js
+++ b/invenio/modules/deposit/static/js/deposit/templates.js
@@ -1,22 +1,22 @@
-var tpl_webdeposit_status_saved = Hogan.compile('Saved <i class="icon-ok"></i>');
-var tpl_webdeposit_status_saved_with_errors = Hogan.compile('<span class="text-warning">Saved, but with errors <i class="icon-warning-sign"></i></span>');
+var tpl_webdeposit_status_saved = Hogan.compile('Saved <i class="glyphicon glyphicon-ok"></i>');
+var tpl_webdeposit_status_saved_with_errors = Hogan.compile('<span class="text-warning">Saved, but with errors <i class="glyphicon glyphicon-warning-sign"></i></span>');
 var tpl_webdeposit_status_saving = Hogan.compile('Saving <img src="/img/loading.gif" />');
-var tpl_webdeposit_status_error = Hogan.compile('<span class="text-error">Not saved due to server error. Please try to reload your browser <i class="icon-warning-sign"></i></span>');
+var tpl_webdeposit_status_error = Hogan.compile('<span class="text-danger">Not saved due to server error. Please try to reload your browser <i class="glyphicon glyphicon-warning-sign"></i></span>');
 var tpl_field_message = Hogan.compile('{{#messages}}<div>{{{.}}}</div>{{/messages}}');
 var tpl_required_field_message = Hogan.compile('{{{label}}} is required.');
 var tpl_flash_message = Hogan.compile('<div class="alert alert-{{state}}"><a class="close" data-dismiss="alert" href="#"">&times;</a>{{{message}}}</div>');
 var tpl_message_success = Hogan.compile('Successfully saved.');
 var tpl_message_errors = Hogan.compile('The form was saved, but there were errors. Please see below.');
-var tpl_message_server_error = Hogan.compile('The form could not be saved, due to a communication problem with the server. Please try to reload your browser <i class="icon-warning-sign"></i>');
+var tpl_message_server_error = Hogan.compile('The form could not be saved, due to a communication problem with the server. Please try to reload your browser <i class="glyphicon glyphicon-warning-sign"></i>');
 var tpl_loader = Hogan.compile('<img src="/img/loading.gif" />');
-var tpl_loader_success = Hogan.compile('<span class="text-success"> <i class="icon-ok"></i></span>');
-var tpl_loader_failed = Hogan.compile('<span class="muted"> <i class="icon-warning-sign"></i></span>');
+var tpl_loader_success = Hogan.compile('<span class="text-success"> <i class="glyphicon glyphicon-ok"></i></span>');
+var tpl_loader_failed = Hogan.compile('<span class="text-muted"> <i class="glyphicon glyphicon-warning-sign"></i></span>');
 var tpl_file_entry = Hogan.compile('<tr id="{{id}}" class="hide">' +
     '<td id="{{id}}_link">{{#download_url}}<a href="{{download_url}}">{{filename}}</a>{{/download_url}}{{^download_url}}{{filename}}{{/download_url}}</td>' +
     '<td>{{filesize}}</td>' +
     '<td width="30%">{{^completed}}<div class="progress{{#striped}} progress-striped{{/striped}} active"><div class="bar" style="width: {{progress}}%;">{{/completed}}</div></div></td>' +
-    '<td><a id="{{id_sort}}" class="sortlink muted" rel="tooltip" title="Re-order files"><i class="icon-reorder"></i></a>&nbsp;{{#removeable}}<a class="rmlink" rel="tooltip" title="Delete file"><i class="icon-trash"></i></a>{{/removeable}}</td>' +
+    '<td><a id="{{id_sort}}" class="sortlink text-muted" rel="tooltip" title="Re-order files"><i class="glyphicon glyphicon-reorder"></i></a>&nbsp;{{#removeable}}<a class="rmlink" rel="tooltip" title="Delete file"><i class="glyphicon glyphicon-trash"></i></a>{{/removeable}}</td>' +
     '</tr>');
 var tpl_file_link = Hogan.compile('<a href="{{download_url}}">{{filename}}</a>');
-var tpl_error = Hogan.compile('<div class="alert alert-error"><a class="close" data-dismiss="alert" href="#"">&times;</a><strong>Error:</strong> {{{message}}}</div>');
+var tpl_error = Hogan.compile('<div class="alert alert-danger"><a class="close" data-dismiss="alert" href="#"">&times;</a><strong>Error:</strong> {{{message}}}</div>');
 var tpl_modal_submitting = Hogan.compile('<div align="center">Submitting <img src="/img/loading.gif" /></div>');

--- a/invenio/modules/deposit/templates/deposit/completed.html
+++ b/invenio/modules/deposit/templates/deposit/completed.html
@@ -20,12 +20,12 @@
 
 {% block body %}
 <div class="row">
-    <div class="span8">
+    <div class="col-md-8">
 
     <div class="well">
         <span class="pull-right">
-            <button class="btn hide" data-toggle="tooltip" title="" ><i class="icon-pencil"></i> Edit</button>
-            <a href="{{url_for('record.metadata', recid=sip.metadata['recid'])}}" class="btn btn-primary" data-toggle="tooltip" title=""><i class="icon-eye-open"></i> Live version</a>
+            <button class="btn hide" data-toggle="tooltip" title="" ><i class="glyphicon glyphicon-pencil"></i> Edit</button>
+            <a href="{{url_for('record.metadata', recid=sip.metadata['recid'])}}" class="btn btn-primary" data-toggle="tooltip" title=""><i class="glyphicon glyphicon-eye-open"></i> Live version</a>
         </span>
         <span class="clearfix"></span>
     </div>
@@ -35,13 +35,13 @@
             <h4>Preview</h4>
         </div>
     </div>
-    <small class="muted">This is a preview of your upload. The public version is available on <a href="{{url_for('record.metadata', recid=sip.metadata['recid'])}}">{{url_for('record.metadata', recid=sip.metadata['recid'], _external=True)}}</a>. If you want to remove your upload, please contact <a href="mailto:{{config.CFG_SITE_SUPPORT_EMAIL}}">{{config.CFG_SITE_SUPPORT_EMAIL}}</a>.</small>
+    <small class="text-muted">This is a preview of your upload. The public version is available on <a href="{{url_for('record.metadata', recid=sip.metadata['recid'])}}">{{url_for('record.metadata', recid=sip.metadata['recid'], _external=True)}}</a>. If you want to remove your upload, please contact <a href="mailto:{{config.CFG_SITE_SUPPORT_EMAIL}}">{{config.CFG_SITE_SUPPORT_EMAIL}}</a>.</small>
     <hr />
     {{format_record(recID=sip.metadata['recid'], xml_record=sip.package, of='hd')|safe}}
     {{format_record(recID=sip.metadata['recid'], xml_record=sip.package, of='hdinfo')|safe}}
 
     </div>
-    <div class="span4">
+    <div class="col-md-4">
         {% include "deposit/myview.html" %}
     </div>
     </div>

--- a/invenio/modules/deposit/templates/deposit/deposition_type.html
+++ b/invenio/modules/deposit/templates/deposit/deposition_type.html
@@ -27,7 +27,7 @@
       {{ _('select or create deposition') }}
       <a class="btn btn-info pull-right"
          href="{{ url_for('webdeposit.create', deposition_type=deposition_type.get_identifier()) }}">
-        <i class="icon-edit icon-white"></i> {{ _('New Deposition') }}
+        <i class="glyphicon glyphicon-edit"></i> {{ _('New Deposition') }}
       </a>
     </small>
   </h3>
@@ -35,18 +35,18 @@
 
 <div class="row">
   {% if my_depositions %}
-  <ul class="nav nav-tabs nav-stacked offset3 span6">
+  <ul class="nav nav-tabs nav-stacked col-md-offset-3 col-md-6">
   {% for dep in my_depositions if not dep.is_finished() %}
     <li> <a href="{{ url_for('webdeposit.run', deposition_type=dep.type.get_identifier(), uuid=dep.id) }}">
-       <i class="icon-chevron-right pull-right"></i>
+       <i class="glyphicon glyphicon-chevron-right pull-right"></i>
         <strong>{{ dep.type.name }}: {{ dep.title or _('Untitled') }}</strong>
-    <span style="font-size: 80%;" class="muted">{{ dep.modified|invenio_pretty_date }}</span>
+    <span style="font-size: 80%;" class="text-muted">{{ dep.modified|invenio_pretty_date }}</span>
      </a>
     </li>
   {% endfor %}
   </ul>
   {% else %}
-  <div class="span12">
+  <div class="col-md-12">
     <strong>{{ _('There is no ongoing deposition.') }}</strong>
   </div>
   {% endif %}
@@ -59,12 +59,12 @@
   <li class="divider" style="overflow: visible;"></li>
 </ul>
 
-  <h4 class="offset2"style="margin-top: 25px;">Past depositions</h4>
+  <h4 class="col-md-offset-1"style="margin-top: 25px;">Past depositions</h4>
 
-   <ul class="nav nav-tabs nav-stacked offset3 span6">
+   <ul class="nav nav-tabs nav-stacked col-md-offset-3 col-md-6">
 {% endif %}
   <li> <a href="{{ url_for('webdeposit.run', deposition_type=dep.type.get_identifier(), uuid=dep.id) }}">
-           <i class="icon-chevron-right pull-right"></i>
+           <i class="glyphicon glyphicon-chevron-right pull-right"></i>
             {{ dep.type.name }}: {{ dep.title or _('Untitled') }}
          </a>
          </li>

--- a/invenio/modules/deposit/templates/deposit/error.html
+++ b/invenio/modules/deposit/templates/deposit/error.html
@@ -20,7 +20,7 @@
 
 {% block body %}
 <div class="row">
-    <div class="span8">
+    <div class="col-md-8">
 
     <div class="progress progress-striped progress-danger" style="height: inherit;">
         <div class="bar" style="width: 100%;">
@@ -28,7 +28,7 @@
         </div>
     </div>
     </div>
-    <div class="span4">
+    <div class="col-md-4">
         {% include "deposit/myview.html" %}
     </div>
     </div>

--- a/invenio/modules/deposit/templates/deposit/index.html
+++ b/invenio/modules/deposit/templates/deposit/index.html
@@ -25,25 +25,25 @@
 </div>
 
 <div class="row">
-  <div id="webdeposit_types_accordion" class="offset3 span6 accordion">
+  <div id="webdeposit_types_accordion" class="col-md-offset-3 col-md-6 panel-group">
     {% for deptype_group in deposition_types.values()|groupby('group') %}
-    <div class="accordion-group">
-      <div class="accordion-heading">
+    <div class="panel panel-default">
+      <div class="panel-heading">
         <h4>
-        <a class="accordion-toggle" data-toggle="collapse"
+        <a data-toggle="collapse"
            data-parent="#webdeposit_types_accordion"
            href="#collapse{{ loop.index }}">
-          <i class="icon-list pull-right"></i> {{ deptype_group.grouper }}
+          <i class="glyphicon glyphicon-list pull-right"></i> {{ deptype_group.grouper }}
         </a>
         </h4>
       </div>
       <div id="collapse{{ loop.index }}" class="collapse">
-        <div class="accordion-inner" style="padding: 0px;">
+        <div class="panel-body" style="padding: 0px;">
           <ul class="nav nav-pills nav-stacked" style="margin-bottom: 0px;">
           {% for deptype in deptype_group.list|sort(attribute='name') %}
             <li>
               <a href="{{ url_for('.deposition_type_index', deposition_type=deptype.get_identifier()) }}">
-                <i class="icon-chevron-right pull-right"></i>
+                <i class="glyphicon glyphicon-chevron-right pull-right"></i>
                 {{ deptype.name }}
                 {% if deptype.type in drafts %}
                 &nbsp;

--- a/invenio/modules/deposit/templates/deposit/myview.html
+++ b/invenio/modules/deposit/templates/deposit/myview.html
@@ -1,7 +1,7 @@
 <div class="well">
     <h2>My uploads</h2>
     {% if not my_depositions %}
-    <p class="muted">You currently have no uploads.</p>
+    <p class="text-muted">You currently have no uploads.</p>
     {% else %}
     {% for dep in my_depositions if not dep.is_finished() %}
     {%- set deposition_type = None if dep.type.is_default() else dep.type.get_identifier() -%}
@@ -14,7 +14,7 @@
                   {{ dep.title }}
               {% else %}
                   {{ _('Untitled') }}
-              {% endif %}</a></td><td>{{ dep.modified|invenio_pretty_date }}</td><td><a href="{{ url_for('webdeposit.delete', deposition_type=deposition_type, uuid=dep.id) }}" class="rmlink" rel="tooltip" title="Delete upload"><i class="icon-trash"></i></a></td>
+              {% endif %}</a></td><td>{{ dep.modified|invenio_pretty_date }}</td><td><a href="{{ url_for('webdeposit.delete', deposition_type=deposition_type, uuid=dep.id) }}" class="rmlink" rel="tooltip" title="Delete upload"><i class="glyphicon glyphicon-trash"></i></a></td>
     </tr>
     {%- if loop.last %}
     </table>

--- a/invenio/modules/deposit/templates/deposit/run_action_bar.html
+++ b/invenio/modules/deposit/templates/deposit/run_action_bar.html
@@ -1,10 +1,10 @@
 <div class="well"{% if margin %}style="margin-top: {{margin}}"{% endif %}>
-    <a class="btn btn-danger pull-left" href="{{ url_for('webdeposit.delete', deposition_type=deposition_type, uuid=uuid) }}"><i class="icon-trash  icon-white"></i> {{ _('Delete') }}</a>
+    <a class="btn btn-danger pull-left" href="{{ url_for('webdeposit.delete', deposition_type=deposition_type, uuid=uuid) }}"><i class="glyphicon glyphicon-trash "></i> {{ _('Delete') }}</a>
     <span class="pull-right">
         <span class="loader hide"><img src="{{ url_for('static', filename='img/loading.gif' ) }}" /></span>
-        <span class="status-indicator muted"></span>&nbsp;
-        <button class="btn form-save" data-toggle="tooltip" title="{{_('Press "Save" to save your upload for editing later, as many times you like.')}}" ><i class="icon-file"></i> Save</button>
-        <button title="{{_('Press "Submit" to finalize and make your upload public (further editing afterwards is  currently not possible).')}}" class="btn btn-primary form-submit"><i class="icon-ok  icon-white"></i> Submit</button>
+        <span class="status-indicator text-muted"></span>&nbsp;
+        <button class="btn form-save" data-toggle="tooltip" title="{{_('Press "Save" to save your upload for editing later, as many times you like.')}}" ><i class="glyphicon glyphicon-file"></i> Save</button>
+        <button title="{{_('Press "Submit" to finalize and make your upload public (further editing afterwards is  currently not possible).')}}" class="btn btn-primary form-submit"><i class="glyphicon glyphicon-ok "></i> Submit</button>
     </span>
     <span class="clearfix"></span>
 </div>

--- a/invenio/modules/deposit/templates/deposit/run_base.html
+++ b/invenio/modules/deposit/templates/deposit/run_base.html
@@ -35,7 +35,7 @@
     {% include "deposit/run_field_label.html" %}
 {%- endmacro -%}
 
-{%- macro field_display(thisfield, field_class="span5", container_class="control-group") -%}
+{%- macro field_display(thisfield, field_class="", container_class="form-group") -%}
     {% include "deposit/run_field.html" %}
 {%- endmacro -%}
 
@@ -67,12 +67,12 @@
 span.ui-icon.ui-icon-circle-triangle-w { color: transparent; cursor: pointer; }
 span.ui-icon.ui-icon-circle-triangle-e { color: transparent; cursor: pointer; }
 
-.typeahead {
+/*.typeahead {
     max-height: 250px;
     overflow-y: auto;
     /* prevent horizontal scrollbar */
-    overflow-x: hidden;
-}
+    /*overflow-x: hidden;*/
+/*}*/
 
 .l{
     size: 10px;
@@ -120,7 +120,7 @@ span.ui-icon.ui-icon-circle-triangle-e { color: transparent; cursor: pointer; }
 </div>
 {% endblock form_submit_dialog %}
 <div class="row">
-    <div id="file_container" class="span8 form-feedback-warning">
+    <div id="file_container" class="col-md-8 form-feedback-warning">
     <div id="flash-message"></div>
     <form enctype="multipart/form-data" name="submitForm" id="submitForm" class="form-horizontal" method="post" action="{{ url_for('.run', deposition_type=deposition_type, uuid=uuid) }}">
     {% block form_header scoped %}{{ form_action_bar() }}{% endblock form_header%}
@@ -128,7 +128,7 @@ span.ui-icon.ui-icon-circle-triangle-e { color: transparent; cursor: pointer; }
     {% block form_title scoped %}
         <h1>{{ form._title }}</h1>
         {% if form._subtitle %}
-            <p class="muted"><small>{{ form._subtitle|safe }}</small></p>
+            <p class="text-muted"><small>{{ form._subtitle|safe }}</small></p>
         {% endif %}
     {% endblock form_title %}
 
@@ -137,7 +137,7 @@ span.ui-icon.ui-icon-circle-triangle-e { color: transparent; cursor: pointer; }
             {% set grouploop = loop %}
             {% block form_group scoped %}
                 {% if grouploop.first %}
-                    <div id="webdeposit_form_accordion" class="accordion">
+                    <div id="webdeposit_form_accordion">
                 {% endif %}
                 {% block form_group_header scoped %}
                     {% if group %}
@@ -151,13 +151,11 @@ span.ui-icon.ui-icon-circle-triangle-e { color: transparent; cursor: pointer; }
                     {% endif %}
 
                     {% block fieldset scoped %}
-                    <fieldset>
                     {% for field in fields %}
                         {% block field_body scoped %}
                             {{ field_display(field) }}
                         {% endblock field_body %}
                     {% endfor %}
-                    </fieldset>
                     {% endblock fieldset %}
                 {% endblock form_group_body%}
 
@@ -176,7 +174,7 @@ span.ui-icon.ui-icon-circle-triangle-e { color: transparent; cursor: pointer; }
     </form>
     </div>
     {% if form._drafting %}
-        <div class="span4">
+        <div class="col-md-4">
             {% include "deposit/myview.html" %}
         </div>
     {% endif %}
@@ -203,7 +201,7 @@ $(document).ready(function() {
     $('#webdeposit_form_accordion').on('shown', function (e) {
         $(e.target).css("overflow", "visible");
     })
-    $('#webdeposit_form_accordion .accordion-body.in.collapse').css("overflow", "visible");
+    $('#webdeposit_form_accordion .panel-collapse.in.collapse').css("overflow", "visible");
 });
 $(document).ready(function() {
     var save_url = '{{ url_for(".save", deposition_type=deposition_type, uuid=uuid, draft_id=draft.id) }}';

--- a/invenio/modules/deposit/templates/deposit/run_field.html
+++ b/invenio/modules/deposit/templates/deposit/run_field.html
@@ -4,12 +4,12 @@
 {%- set field_class = thisfield.widget_classes if thisfield.widget_classes is not none else field_class %}
 <div class="{{container_class}} {{ "error" if thisfield.errors }}{{ 'hide' if thisfield.flags.hidden}}" id="state-group-{{ thisfield.name }}">
     {{ field_label(thisfield) }}
-    <div class="{{ 'controls' if thisfield.widget.__class__.__name__ not in ['plupload_widget', 'PLUploadWidget'] }}" id="field-{{ thisfield.name }}">
+    <div id="field-{{ thisfield.name }}" class="col-md-8">
         {{ thisfield(class_= field_class + " " + thisfield.short_name) }}
         {%- if thisfield.description %}
-            <p class="muted field-desc"><small>{{thisfield.description|urlize}}</small></p>
+            <p class="text-muted field-desc"><small>{{thisfield.description|urlize}}</small></p>
         {%- endif %}
-        <div class="alert help-inline {{ 'alert-error' if thisfield.errors else 'hide' }}" id="state-{{ thisfield.name }}" style="margin-top: 5px;{% if thisfield.errors %} display:block;{% endif %}">
+        <div class="alert help-inline {{ 'alert-danger' if thisfield.errors else 'hide' }}" id="state-{{ thisfield.name }}" style="margin-top: 5px;{% if thisfield.errors %} display:block;{% endif %}">
             {%- for error in thisfield.errors %}
                 <div>{{ error }}</div>
             {%- endfor %}

--- a/invenio/modules/deposit/templates/deposit/run_field_label.html
+++ b/invenio/modules/deposit/templates/deposit/run_field_label.html
@@ -1,7 +1,7 @@
 {% if thisfield.label.text %}
-    <label class="control-label{{' required' if thisfield.flags.required}}{{ ' error' if thisfield.errors }}" for="{{thisfield.label.field_id}}">
+    <label class="control-label col-md-3 {{' required' if thisfield.flags.required}}{{ ' error' if thisfield.errors }}" for="{{thisfield.label.field_id}}">
         {%- if thisfield.icon %}
-            <span class="" style="margin-right: 5px; margin-top: 5px;"><i class={{ thisfield.icon}}></i></span>
+            <span class=""><i class="glyphicon glyphicon-{{ thisfield.icon }}"></i></span>
         {%- endif %}
         {{ thisfield.label.text }}
     </label>

--- a/invenio/modules/deposit/templates/deposit/run_field_subform.html
+++ b/invenio/modules/deposit/templates/deposit/run_field_subform.html
@@ -1,4 +1,4 @@
-<div class="control-group {{ "error" if thisfield.errors }}" id="state-group-{{ thisfield.name }}">
+<div class="form-group {{ "error" if thisfield.errors }}" id="state-group-{{ thisfield.name }}">
     {{ field_label(thisfield) }}
 </div>
 {% for subfield in thisfield.form %}

--- a/invenio/modules/deposit/templates/deposit/run_group_start.html
+++ b/invenio/modules/deposit/templates/deposit/run_group_start.html
@@ -1,9 +1,9 @@
-<div class="accordion-group">
-    <div class="accordion-heading">
+<div class="panel panel-default">
+    <div class="panel-heading">
         {% if group.meta.indication %}
-            <span class="accordion-toggle muted pull-right">{{ group.meta.indication }}</span>
+            <span class="text-muted pull-right">{{ group.meta.indication }}</span>
         {% endif %}
-        <a class="accordion-toggle" data-toggle="collapse" href="#collapse-{{ idx }}"> {{ group.name }} <b class="caret" style="margin-top: 8px;"></b></a>
+        <a data-toggle="collapse" href="#collapse-{{ idx }}"> {{ group.name }} <b class="caret"></b></a>
     </div>
-    <div id="collapse-{{ idx }}" class="accordion-body collapse {{ 'in' if group.meta.classes is none else group.meta.classes }}">
-    <div class="accordion-inner">
+    <div id="collapse-{{ idx }}" class="panel-collapse collapse {{ 'in' if group.meta.classes is none else group.meta.classes }}">
+    <div class="panel-body">

--- a/invenio/modules/deposit/templates/deposit/widget_plupload.html
+++ b/invenio/modules/deposit/templates/deposit/widget_plupload.html
@@ -16,10 +16,10 @@
         <tbody id="filelist">
         </tbody>
     </table>
-    <a class="btn" id="pickfiles" >Select files...</a>
-    <a class="btn btn-success disabled" id="uploadfiles"><i class="icon-upload icon-white"></i> Start upload</a>
+    <a class="btn btn-default" id="pickfiles" >Select files...</a>
+    <a class="btn btn-success disabled" id="uploadfiles"><i class="glyphicon glyphicon-upload"></i> Start upload</a>
     <a class="btn btn-danger" id="stopupload"
-    style="display:none;"><i class="icon-stop icon-white"></i> Cancel upload</a>
+    style="display:none;"><i class="glyphicon glyphicon-stop"></i> Cancel upload</a>
     <span id="upload_speed" class="pull-right"></span>
     <div id="upload-errors"></div>
 </div>

--- a/invenio/modules/deposit/views/deposit.py
+++ b/invenio/modules/deposit/views/deposit.py
@@ -447,7 +447,7 @@ def autocomplete(form_type, field_name):
     limit = request.args.get('limit', 50, type=int)
 
     try:
-        form = forms[form_type]()
+        form = getattr(forms, form_type)()
         result = form.autocomplete(field_name, term, limit=limit)
         result = result if result is not None else []
     except KeyError:

--- a/invenio/modules/formatter/format_elements/bfe_fulltext.py
+++ b/invenio/modules/formatter/format_elements/bfe_fulltext.py
@@ -105,7 +105,7 @@ def format_element(bfo, style, separator='; ', show_icons='no', focus_on_main_fi
                 # rather study doc type, and base ourselves on
                 # Main/Additional/Plot etc.
                 continue
-            out += ['<li class="nav-header"><strong>%s:</strong></li>' % descr]
+            out += ['<li class="dropdown-header"><strong>%s:</strong></li>' % descr]
             urls_dict = {}
             for url, name, url_format in urls:
                 if name not in urls_dict:
@@ -115,7 +115,7 @@ def format_element(bfo, style, separator='; ', show_icons='no', focus_on_main_fi
             for name, urls_and_format in urls_dict.items():
                 if len(urls_dict) > 1:
                     print_name = "<em>%s</em>" % name
-                    url_list = ['<li class="nav-header">' + print_name + "</li>"]
+                    url_list = ['<li class="dropdown-header">' + print_name + "</li>"]
                 else:
                     url_list = []
                 for url, url_format in urls_and_format:

--- a/invenio/modules/formatter/templates/format/record/Default_HTML_brief.tpl
+++ b/invenio/modules/formatter/templates/format/record/Default_HTML_brief.tpl
@@ -1,7 +1,7 @@
 {% macro render_record_footer(number_of_displayed_authors) %}
     <p>
       {% if record.get('number_of_authors', 0) > 0 %}
-      <i class="icon-user"></i> by
+      <i class="glyphicon glyphicon-user"></i> by
         {% set authors = record.get('authors[:].full_name', []) %}
         {% set sep = joiner("; ") %}
         {% for full_name in authors[0:number_of_displayed_authors] %} {{ sep() }}
@@ -12,7 +12,7 @@
         {% if record.get('number_of_authors', 0) > number_of_displayed_authors %}
         {{ sep() }}
         <a href="#authors_{{ record['recid'] }}"
-           class="muted" data-toggle="modal"
+           class="text-muted" data-toggle="modal"
            data-target="#authors_{{ record['recid'] }}">
             <em>{{ _(' et al') }}</em>
         </a>
@@ -20,14 +20,14 @@
 
       |
       {% endif %}
-      <i class="icon-calendar"></i> {{ record['creation_date']|invenio_format_date() }}
+      <i class="glyphicon glyphicon-calendar"></i> {{ record['creation_date']|invenio_format_date() }}
       {# Citations link #}
       {%- if config.CFG_BIBRANK_SHOW_CITATION_LINKS -%}
         {%- set num_citations = record['_cited_by_count'] -%}
         {%- if num_citations -%}
          |
         <a href="{{ url_for('.search', p="refersto:recid:%d" % recid) }}">
-           <i class="icon-share"></i>
+           <i class="glyphicon glyphicon-share"></i>
           {{ _("%i citations") % num_citations if num_citations > 1 else _("1 citation") }}
         </a>
         {%- endif -%}
@@ -39,7 +39,7 @@
         {%- if num_comments -%}
          |
         <a href="{{ url_for('comments.comments', recid=recid) }}">
-          <i class="icon-comment"></i>
+          <i class="glyphicon glyphicon-comment"></i>
           {{ _("%i comments") % num_comments if num_comments > 1 else _("1 comment") }}
         </a>
         {%- endif -%}
@@ -51,7 +51,7 @@
         {%- if num_reviews -%}
          |
         <a href="{{ url_for('comments.reviews', recid=recid) }}">
-          <i class="icon-eye-open"></i>
+          <i class="glyphicon glyphicon-eye-open"></i>
           {{ _("%i reviews") % num_reviews if num_reviews > 1 else _("1 review") }}
         </a>
         {%- endif -%}
@@ -59,7 +59,7 @@
 
       | <a href="{{ url_for('search.search', p='recid:%s' % recid, rm='wrd') }}">{{ _("Similar records") }}</a>
 
-      {% if record['keywords']|length %} | <i class="icon-tag"></i>
+      {% if record['keywords']|length %} | <i class="glyphicon glyphicon-tag"></i>
       {% for keyword in record['keywords'] %}
       <span class="label">
         <a href="{{ url_for('search.search', p='keyword:' + keyword['term']) }}">
@@ -95,19 +95,19 @@
 {% endmacro %}
 
 {% macro record_info() %}
-  {{ bfe_primary_report_number(bfo, prefix='<i class="icon-qrcode"></i> ') }}
-  {{ bfe_additional_report_numbers(bfo, prefix='<i class="icon-qrcode"></i> ',
-                                   separator=' <i class="icon-qrcode"></i> ') }}
+  {{ bfe_primary_report_number(bfo, prefix='<i class="glyphicon glyphicon-qrcode"></i> ') }}
+  {{ bfe_additional_report_numbers(bfo, prefix='<i class="glyphicon glyphicon-qrcode"></i> ',
+                                   separator=' <i class="glyphicon glyphicon-qrcode"></i> ') }}
 
-  {{ bfe_publi_info(bfo, prefix='| <i class="icon-book"></i> ') }}
-  {{ bfe_doi(bfo, prefix='| <i class="icon-barcode"></i> ') }}
-  {# '<a href="http://dx.doi.org/%(doi)s" title="DOI" target="_blank"><i class="icon-barcode"></i> %(doi)s</a>'|format(doi=record['doi']) if record.get('doi') #}
+  {{ bfe_publi_info(bfo, prefix='| <i class="glyphicon glyphicon-book"></i> ') }}
+  {{ bfe_doi(bfo, prefix='| <i class="glyphicon glyphicon-barcode"></i> ') }}
+  {# '<a href="http://dx.doi.org/%(doi)s" title="DOI" target="_blank"><i class="glyphicon glyphicon-barcode"></i> %(doi)s</a>'|format(doi=record['doi']) if record.get('doi') #}
 
 {% endmacro %}
 
 {% block record_brief %}
 <div class="htmlbrief">
-    {{ bfe_fulltext(bfo, show_icons="yes", prefix='<ul class="nav nav-pills pull-right" style="margin-top: -10px;"><li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" title="Download" href="#"><i class="icon-download-alt"></i><span class="caret"></span></a>', suffix='</li></ul>', focus_on_main_file="yes") }}
+    {{ bfe_fulltext(bfo, show_icons="yes", prefix='<ul class="nav nav-pills pull-right" style="margin-top: -10px;"><li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" title="Download" href="#"><i class="glyphicon glyphicon-download-alt"></i><span class="caret"></span></a>', suffix='</li></ul>', focus_on_main_file="yes") }}
     {% block record_header %}
     <h4 class="media-heading">
         <a href="{{ url_for('record.metadata', recid=record['recid']) }}">

--- a/invenio/modules/formatter/templates/format/record/Picture_HTML_brief.tpl
+++ b/invenio/modules/formatter/templates/format/record/Picture_HTML_brief.tpl
@@ -6,7 +6,7 @@
         {{ record.get('title.title', '') }}
     </a>
     {{ '/' if record.get('title_parallel.title') }}
-    <small class="muted">
+    <small class="text-muted">
         {{ record.get('title_parallel.title', '')}}
     </small>
 </h4>

--- a/invenio/modules/linkbacks/templates/linkbacks/index.html
+++ b/invenio/modules/linkbacks/templates/linkbacks/index.html
@@ -37,7 +37,7 @@
 
   {%- if linkbacks -%}
   <div class="row">
-    <div class="span5">
+    <div class="col-md-5">
     <table class="table table-striped table-condensed">
       <thead>
         <tr>

--- a/invenio/modules/messages/templates/messages/add.html
+++ b/invenio/modules/messages/templates/messages/add.html
@@ -101,13 +101,15 @@
 {% block body %}
 <form name="write_message" action="{{ url_for('.add') }}" method="post" class="form-horizontal">
     {{ form.csrf_token }}
-    {{ render_field(form.sent_to_user_nicks) }}
-    {{ render_field(form.sent_to_group_names) }}
-    {{ render_field(form.subject) }}
-    {{ render_field(form.body) }}
-    {{ render_field(form.received_date) }}
-    <div class="form-actions">
-        <input type="submit" name="send_button" value="{{ _("Send") }}" class="btn btn-primary"/>
+    {{ render_field(form.sent_to_user_nicks, label_size=2, field_size=10) }}
+    {{ render_field(form.sent_to_group_names, label_size=2, field_size=10) }}
+    {{ render_field(form.subject, label_size=2, field_size=10) }}
+    {{ render_field(form.body, label_size=2, field_size=10) }}
+    {{ render_field(form.received_date, label_size=2, field_size=10) }}
+    <div class="form-group">
+        <div class="col-md-offset-2 col-md-10">
+            <input type="submit" name="send_button" value="{{ _("Send") }}" class="btn btn-primary"/>
+        </div>
     </div>
 </form>
 {% endblock %}

--- a/invenio/modules/messages/templates/messages/menu.html
+++ b/invenio/modules/messages/templates/messages/menu.html
@@ -17,8 +17,8 @@
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #}
 
-<ul class="dropdown-menu">
-  <li class="nav-header">{{ _('Messages') }}
+<ul class="dropdown-menu" style="min-width: 400px;">
+  <li class="dropdown-header">{{ _('Messages') }}
     <a class="pull-right" href="{{ url_for('webmessage.add') }}">
       {{ _('Write message') }}
     </a>
@@ -26,7 +26,7 @@
   <li class="divider"></li>
   {% for m, um in messages %}
   <li class="row">
-    {% set a_class = "span5 alert-info" if um.status == 'N' else "span5" %}
+    {% set a_class = "col-md-5 alert-info" if um.status == 'N' else "col-md-5" %}
     <a style="margin-bottom: 1px;" class="{{ a_class }}" href="{{ url_for('webmessage.view', msgid=m.id) }}">
       <div style="width: 100%; float: left;">
         <div style="float:left; width: 30px; padding: 4px;">
@@ -44,8 +44,8 @@
     </a>
   </li>
   {% else %}
-  <li class="row">
-    <strong class="span5" style="padding: 0 15px;">{{ _('Empty inbox') }}</strong>
+  <li role="presentation" class="col-sm-12 col-xs-12">
+    <label>{{ _('Empty inbox') }}</label>
   </li>
   {% endfor %}
   <li class="divider"></li>

--- a/invenio/modules/messages/templates/messages/view.html
+++ b/invenio/modules/messages/templates/messages/view.html
@@ -21,7 +21,7 @@
 {% block body %}
 
 <div class="row">
-<dl class="dl-horizontal well offset1 span5">
+<dl class="dl-horizontal well col-md-offset-1 col-md-5">
   <dt>{{ _("From") }}</dt>
   <dd>
     <a href="{{ url_for('.add', sent_to_user_nicks=m.message.user_from.nickname) }}">
@@ -47,7 +47,7 @@
 </dl>
 </div>
 <div class="row">
-  <div style="min-height: 100px;" class="offset1 span10 thumbnail">
+  <div style="min-height: 100px;" class="col-md-offset-1 col-md-10 thumbnail">
   {{ m.message.body }}
   </div>
 </div>

--- a/invenio/modules/messages/views.py
+++ b/invenio/modules/messages/views.py
@@ -50,7 +50,7 @@ class MessagesMenu(object):
             )).scalar()
 
         out = '<div data-menu="click" data-menu-source="' + url_for('webmessage.menu') + '">'
-        out += '<i class="icon-envelope icon-white"></i>'
+        out += '<i class="glyphicon glyphicon-envelope"></i>'
         if unread:
             out += ' <span class="badge badge-important">%d</span>' % unread
         out += "</div>"

--- a/invenio/modules/records/templates/records/back_to_search_links.html
+++ b/invenio/modules/records/templates/records/back_to_search_links.html
@@ -24,7 +24,7 @@
 <div>
   <span class='moreinfo'>
     <a href="{{ url_for(last_query, ln=g.ln) }}">
-      <i class="icon-arrow-left"></i> {{ _('Back to search') }}
+      <i class="glyphicon glyphicon-arrow-left"></i> {{ _('Back to search') }}
     </a>
 
   {%- if nb_recids > 1 -%}
@@ -39,36 +39,36 @@
       {# to display only the links to the next and last record #}
       <span><b>{{ numrec }}</b> {{_('of')}} <b>{{ nb_recids }}</b></span>
       <a href="{{ url_for('record.metadata', recid=recIDnext, ln=g.ln) }}">
-        <i class="icon-step-forward icon-large"></i>
+        <i class="glyphicon glyphicon-step-forward"></i>
       </a>
       <a href="{{ url_for('record.metadata', recid=recIDlast, ln=g.ln) }}">
-        <i class="icon-fast-forward icon-large"></i>
+        <i class="glyphicon glyphicon-fast-forward"></i>
       </a>
 
   {%- elif pos == nb_recids - 1 -%}
       {# to display only the links to the first and previous record #}
       <a href="{{ url_for('record.metadata', recid=recIDfirst, ln=g.ln) }}">
-        <i class="icon-fast-backward icon-large"></i>
+        <i class="glyphicon glyphicon-fast-backward"></i>
       </a>
       <a href="{{ url_for('record.metadata', recid=recIDprev, ln=g.ln) }}">
-        <i class="icon-step-backward icon-large"></i>
+        <i class="glyphicon glyphicon-step-backward"></i>
       </a>
       <span><b>{{ numrec }}</b> {{_('of')}} <b>{{ nb_recids }}</b></span>
 
     {%- else -%}
       {# to display all links: first, previous, next, last record, and "back to search" #}
       <a href="{{ url_for('record.metadata', recid=recIDfirst, ln=g.ln) }}">
-        <i class="icon-fast-backward icon-large"></i>
+        <i class="glyphicon glyphicon-fast-backward"></i>
       </a>
       <a href="{{ url_for('record.metadata', recid=recIDprev, ln=g.ln) }}">
-        <i class="icon-step-backward icon-large"></i>
+        <i class="glyphicon glyphicon-step-backward"></i>
       </a>
       <span class="outof"><b>{{ numrec }}</b> {{_('of')}} <b>{{ nb_recids }}</b></span>
       <a href="{{ url_for('record.metadata', recid=recIDnext, ln=g.ln) }}">
-        <i class="icon-step-forward icon-large"></i>
+        <i class="glyphicon glyphicon-step-forward"></i>
       </a>
       <a href="{{ url_for('record.metadata', recid=recIDlast, ln=g.ln) }}">
-        <i class="icon-fast-forward icon-large"></i>
+        <i class="glyphicon glyphicon-fast-forward"></i>
       </a>
     {%- endif -%}
   {%- endif -%}

--- a/invenio/modules/records/templates/records/base.html
+++ b/invenio/modules/records/templates/records/base.html
@@ -34,7 +34,7 @@
 
   {% block record_restriction_flag %}
   {% if g.bibrec.is_restricted %}
-  <div class="alert alert-error"><b>{{ _('Restricted') }}</b>
+  <div class="alert alert-danger"><b>{{ _('Restricted') }}</b>
     {%- if g.bibrec.is_processed %} {{ _('Processed Record') }}
     {%- endif -%}</div>
   {% endif %}
@@ -48,7 +48,7 @@
       <a href="{{ url_for(tab.key, recid=recid) if tab.enabled else '#' }}">
         {{ tab.label }}
         {% if tab.count and tab.count > -1 %}
-          &nbsp;<small class="muted">({{ tab.count }})</small>
+          &nbsp;<small class="text-muted">({{ tab.count }})</small>
         {% endif %}
       </a>
     </li>

--- a/invenio/modules/records/templates/records/citations.html
+++ b/invenio/modules/records/templates/records/citations.html
@@ -32,7 +32,7 @@
 
   {%- if citations.citinglist -%}
   <h4>{{ _('Cited by: %i records') % (citations.citinglist|length,) }}</h4>
-  <ul class="unstyled">
+  <ul class="list-unstyled">
   {%- for c in citations.citinglist -%}
   <li>
     <span class="badge">{{ c[1] }}</span>
@@ -49,7 +49,7 @@
 
   {%- if citations.co_cited-%}
   <h4>{{ _('Co-cited with: %s records') % (citations.co_cited|length,) }}</h4>
-  <ul class="unstyled">
+  <ul class="list-unstyled">
   {%- for c in citations.co_cited-%}
   <li>
     <span class="badge">{{ c[1] }}</span>

--- a/invenio/modules/records/templates/records/keywords.html
+++ b/invenio/modules/records/templates/records/keywords.html
@@ -28,7 +28,7 @@
   {#
    # FIXME add different formats
    #}
-  <ul class="unstyled">
+  <ul class="list-unstyled">
   {%- for k,v in keywords.iteritems()-%}
     <li>
       <a href="{{ url_for('search.search', p='keyword:"%s"' % (k,)) }}">

--- a/invenio/modules/records/templates/records/metadata.html
+++ b/invenio/modules/records/templates/records/metadata.html
@@ -53,19 +53,19 @@ div.star:hover {
 </style>
 
   <div class="row">
-  <div class="span12">
+  <div class="col-md-12">
     <div class="well">
     <div class="row">
-      <div style="text-align: center;" class="span3">
+      <div style="text-align: center;" class="col-md-3">
         {{ format_record(recid, of='HDFILE', ln=g.ln)|safe }}
       </div>
-      <div style="text-align: center;" class="span5">
+      <div style="text-align: center;" class="col-md-5">
       {%- if config.CFG_WEBCOMMENT_ALLOW_REVIEWS -%}
         {{ get_mini_reviews(recid=recid, ln=g.ln)|safe }}
       {%- endif -%}
       &nbsp;
       </div>
-      <div class="span3">
+      <div class="col-md-3">
         {{ format_record(recid, of='HDACT', ln=g.ln)|safe }}
       </div>
     </div>

--- a/invenio/modules/records/templates/records/usage.html
+++ b/invenio/modules/records/templates/records/usage.html
@@ -26,9 +26,9 @@
   </div>
 
   {%- if viewsimilarity -%}
-  <div class="span6">
+  <div class="col-md-6">
   <h4>{{ _("People who viewed this page also viewed:") }}</h4>
-  <ul class="unstyled">
+  <ul class="list-unstyled">
   {%- for c in viewsimilarity -%}
   <li>
     <span class="badge">{{ c[1] }}</span> &nbsp;
@@ -41,9 +41,9 @@
   {%- endif -%}
 
   {%- if downloadsimilarity -%}
-  <div class="span5">
+  <div class="col-md-5">
   <h4>{{ _("People who downloaded files from this page also viewed:") }}</h4>
-  <ul class="unstyled">
+  <ul class="list-unstyled">
   {%- for c in downloadsimilarity -%}
   <li>
     <span class="badge">{{ c[1] }}</span> &nbsp;
@@ -56,9 +56,9 @@
   {%- endif -%}
 
   {%- if downloadgraph -%}
-  <div class="span5">
+  <div class="col-md-5">
   <h4>{{ _("Download history graph") }}</h4>
-  <ul class="unstyled">
+  <ul class="list-unstyled">
   {{ downloadgraph|safe }}
   </ul>
   {%- endif -%}

--- a/invenio/modules/search/forms.py
+++ b/invenio/modules/search/forms.py
@@ -54,7 +54,8 @@ class EasySearchForm(InvenioBaseForm):
         data_source=lambda: url_for('search.autocomplete', field='collaboration'))
     k = AutocompleteField(_('Keywords'), data_provide="typeahead-url",
         data_source=lambda: url_for('search.autocomplete', field='keyword'))
-    journal = FormField(JournalForm, widget=RowWidget())
+    journal = FormField(JournalForm, widget=RowWidget(
+        classes={0:'col-xs-6', 1:'col-xs-3', 2: 'col-xs-3'}))
 
 
 class GetCollections(object):

--- a/invenio/modules/search/static/js/search/facet.js
+++ b/invenio/modules/search/static/js/search/facet.js
@@ -326,15 +326,15 @@
 
   $.fn.facet.defaults = {
     box_builder: function(name, title) {
-      return '<div class="accordion-group">' +
-            '<div class="accordion-heading">' +
-              '<a class="accordion-toggle" data-toggle="collapse"' +
-                ' data-target=".accordion-body.' + name + '">' +
+      return '<div class="panel panel-default">' +
+            '<div class="panel-heading">' +
+              '<a data-toggle="collapse"' +
+                ' data-target=".panel-collapse.' + name + '">' +
                     title +
                 '</a>' +
               '</div>' +
-              '<div class="' + name + ' accordion-body collapse">' +
-                '<div class="accordion-inner context">' +
+              '<div class="' + name + ' panel-collapse collapse">' +
+                '<div class="panel-body context">' +
                   '<!-- AJAX load -->' +
                 '</div>' +
               '</div>' +
@@ -349,7 +349,7 @@
             '</div>';
     },
     button_builder: function(title) {
-      return '<span class="btn btn-mini">'+title+'</span>';
+      return '<span class="btn btn-xs">'+title+'</span>';
     },
     clear_button_builder: function(title) {
       return '<span class="pull-right btn btn-danger">'+title+'</span>';

--- a/invenio/modules/search/static/js/search/typeahead.js
+++ b/invenio/modules/search/static/js/search/typeahead.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2012 CERN.
+ * Copyright (C) 2013 CERN.
  *
  * Invenio is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -24,109 +24,343 @@
 
   "use strict"
 
-  // It is necessary to import Bootstrap Typeahead before.
-  var Typeahead = $.fn.typeahead.Constructor;
+  function SearchTypeahead(autocompleteTypeKeys, keywords) {
 
-  var orig = {
-    lookup: $.fn.typeahead.Constructor.prototype.lookup,
-    render: $.fn.typeahead.Constructor.prototype.render,
-    matcher:$.fn.typeahead.Constructor.prototype.matcher,
-    select:$.fn.typeahead.Constructor.prototype.select
-  };
+    var field = this;
 
-  // Let's inherit Typeahead.
-  function SearchTypeahead(e, o) { Typeahead.call(this, e, o) }
-
-  SearchTypeahead.prototype = new Typeahead();
-
-  $.extend(SearchTypeahead.prototype, {
-    lookup: function(event) {
-      var query = this.$element.val(),
-          sources = this.options.sources,
-          m = query.lastIndexOf(':'),
-          type = query.substr(0,m),
-          n = type.lastIndexOf(' ');
-      if (0<n && n<m) {
-        type = type.substr(n+1);
-      }
-      if (m>query.lastIndexOf(' ') && type in sources) {
-        this.options.type = 'data';
-        this.source = sources[type];
-      } else {
-        this.options.type = 'search';
-        this.source = this.options.source;
-      }
-      //this.source = $.isFunction(this.source) ? this.source() : this.source
-      orig.lookup.call(this);
-    },
-    select: function() {
-      var val = this.$menu.find('.active').attr('data-value')
-        , cwrap = (val.lastIndexOf(' ') > 0)?'"':''
-
-      if (this.options.type == 'data') {
-        var m = this.query.lastIndexOf(':')
-          , newVal = this.$element.val().substr(0, m);
-        if (~m) {
-          newVal += ':'+cwrap;
-        }
-        this.$element.val(newVal+val+cwrap+' ');
-        this.$element.change();
-        this.options.type = 'search';
-        return this.hide();
-      }
-
-      if (this.options.type == 'search') {
-      var m = this.query.lastIndexOf(' '),
-          im = (m<0)?0:m+1,
-          p = this.$element.val(),
-          op = ("+-|".indexOf(p[im])>-1)?p[im]:'',
-          newVal = p.substr(0, m);
-      if (~m) {
-        newVal += ' ';
-      }
-      this.$element.val(newVal+op+val);
-      this.$element.change();
-      return this.hide();
-      }
-
-      orig.select.call(this);
-      return this;
-    },
-
-    matcher: function(item) {
-
-      if (this.options.type == 'data') {
-        var m = this.query.lastIndexOf(':'),
-            search = this.query.substr(m + 1).toLowerCase();
-        return search.length && ~item.toLowerCase().indexOf(search);
-      }
-
-      if (this.options.type == 'search') {
-        var m = this.query.lastIndexOf(' '),
-            offset = 0,
-            search = this.query.substr(m + 1).toLowerCase();
-        if (search.length && "+-|".indexOf(search[0]) > -1) {
-          offset = 1;
-        }
-        return search.length &&
-          ~item.toLowerCase().indexOf(search.substr(offset));
-      }
-
-      return orig.matcher.call(this, item);
+    var lowercaseKeywords = [];
+    for (var idx in keywords) {
+      lowercaseKeywords.push(keywords[idx].toLowerCase())
     }
-  });
 
-  $.fn.searchTypeahead = function (option) {
-    return this.each(function () {
-      var $this = $(this)
-        , data = $this.data('typeahead')
-        , options = typeof option == 'object' && option
-      if (!data) $this.data('typeahead', (data = new SearchTypeahead(this, options)))
-      if (typeof option == 'string') data[option]()
-    })
+    function getLastClosedBracketIdx(str) {
+      var lastClosedIdx = str.lastIndexOf("\"");
+
+      // count number of occurencies
+      var count = str.match(/\"/g);
+      if (count == null)
+        return -1;
+
+      if ((count.length % 2) == 0)
+        return lastClosedIdx;
+
+      return str.lastIndexOf("\"", lastClosedIdx - 1);
+    }
+
+    function getLastBracketsIdx(str) {
+      var bracketsIdx = str.lastIndexOf('"');
+      if (bracketsIdx == -1)
+        return {
+          lastClosed: -1,
+          lastOpened: -1,
+        };
+
+      var closedBracketIdx = getLastClosedBracketIdx(str);
+
+      // open bracket
+      if (bracketsIdx > closedBracketIdx)
+        return {
+          lastClosed: closedBracketIdx,
+          lastOpened: bracketsIdx
+        }
+
+      return {
+        lastClosed: closedBracketIdx,
+        lastOpened: -1
+      };
+    }
+
+    function getLastOccurence(str, pattern, limit) {
+      var result, savedRes;
+
+      if (typeof limit == 'undefined') {
+        limit = str.length;
+      }
+
+      do {
+        savedRes = result;
+        result = pattern.exec(str);
+      } while (result !== null && result.index <= limit);
+
+      if (typeof savedRes == 'undefined')
+        return {
+          start: -1,
+          end: -1
+        }
+
+      return {
+        start: savedRes.index,
+        end: savedRes.index + savedRes[0].length
+      }
+    }
+
+    function getLastSpace(str, limit) {
+      // actually one or more spaces
+      return getLastOccurence(str, /\s+/g, limit);
+    }
+
+    function getLastColon(str, limit) {
+      // colon, any number of spaces then optional qoutation mark
+      // all must be precieded by non-whitespace character, which is not included
+      // in (start, end) range
+      var res = getLastOccurence(str, /[^\s]:\s*[\"]*/g, limit - 1);
+      /*"*/ // just to fix broken string highlighting in sublime :)
+      
+      // +1 because of checking for a preceding char
+      if (res.start > -1)
+        res.start += 1;
+
+      return res;
+    }
+
+    function getAutocompleteValueCutoffInd(str, initialIdx) {
+
+      /*
+        @returns dictionary with two values different only 
+          in case of existing open bracket
+          inner - index of the content after the brackets
+          withBrackets - index of an eventual bracket
+      */
+
+      if (typeof initialIdx == 'undefined') {
+        initialIdx = str.length;
+      }
+
+      var bracketsIdx = getLastBracketsIdx(str);
+
+      // value cutoff at an opened bracket
+      if (bracketsIdx.lastOpened > -1) {
+        return {
+          inner: bracketsIdx.lastOpened + 1,
+          withBrackets: bracketsIdx.lastOpened
+        }
+      }
+      // closed bracket is the last sign
+      if (bracketsIdx.lastClosed == str.length - 1) {
+        return {
+          inner: str.length - 1,
+          withBrackets: str.length - 1
+        }
+      }
+
+      var spaceIdx = getLastSpace(str);
+
+      // length - 2 to avoid getting the colon when it is the last character
+      var colonIdx = getLastColon(str, str.length - 2);
+
+      return {
+        inner: Math.max(colonIdx.end, spaceIdx.end, 0),
+        withBrackets: Math.max(colonIdx.end, spaceIdx.end, 0)
+      }
+    }
+
+    function getLastQueryCutoffIdx(str) {
+
+      // cutoff index of last query, so expresion like a keyword:
+      // AND, OR... author:, abstract:,
+      // or a type:value pair e.g.:
+      // author:"Robertson N A", author:Robe
+      // whatever is after the colon
+
+      var cutoff = getAutocompleteValueCutoffInd(str);
+      var colonIdx = getLastColon(str, cutoff.inner);
+
+      if (colonIdx.end !== cutoff.inner)
+        return {
+          typeStart: -1,
+          typeEnd: -1,
+          valueWithBracketsStart: cutoff.withBrackets,
+          valueStart: cutoff.inner
+        }
+
+      // look for a type before the colon
+      var spaceIdx = getLastSpace(str, colonIdx.start);
+
+      return {
+        typeStart: Math.max(spaceIdx.end, 0),
+        typeEnd: colonIdx.start,
+        valueWithBracketsStart: cutoff.withBrackets,
+        valueStart: colonIdx.end
+      }
+    }
+
+    function getQuery(str) {
+
+      /// converts input field string to format type:value
+      /// parsable later with parseQuery()
+
+      var indices = getLastQueryCutoffIdx(str);
+      var searchQuery = str.substring(indices.valueWithBracketsStart, str.lenght);
+      
+      if (indices.typeStart == -1 || indices.typeEnd == -1)
+        return searchQuery;
+      
+      var type = str.substring(indices.typeStart, indices.typeEnd);
+
+      if (searchQuery && type in autocompleteTypeKeys)
+          return type + ':' + searchQuery;
+
+      return searchQuery;
+    }
+
+    function bracketStr(str) {
+      if (str[0] == '\"')
+        return str + '"';
+      return '"' + str + '"';
+    }
+
+    function parseQuery(str, colonChar)
+    /// divides by colon sign already prepared query
+    {
+      if (typeof colonChar == 'undefined')
+        colonChar = ':'
+
+      var colonIdx = str.indexOf(colonChar);
+      if (colonIdx == -1)
+        return {
+          value: str,
+          type: 'KWORD'
+        }
+
+      return {
+        value: str.substring(colonIdx + colonChar.length, str.length),
+        type: str.substring(0, colonIdx)
+      }
+    }
+
+    function mergeWithInputValue(value, typedText) {
+
+      if (value.length == 0)
+        return typedText;
+
+      // the last char is closed bracket
+      // open the bracket to autocomplete the stuf inside the brackets
+      if (typedText[typedText.length - 1] == '\"' && getLastBracketsIdx(typedText).lastOpened == -1)
+        typedText = typedText.substring(0, typedText.length - 1);
+
+      // fix for completition of when the last value is a boolean keyword (ends with a space)
+      // ignore the space at the end
+      if (typedText[typedText.length - 1] == ' ')
+        typedText = typedText.substring(0, typedText.length - 1);
+
+      // substitute with query on blur - query if full query
+      var query = parseQuery(value);
+      // type 'KWORD' means that 'value' doesn't have the query type (apparently no colon ;) )
+      // so for example it's just a value for the completition from the dropdown
+      if (query.type !== 'KWORD' && query.value) {
+        
+        var parsingIndices = getLastQueryCutoffIdx(typedText);
+        var strPrecedingQuery = typedText.substring(0, parsingIndices.typeStart);
+        if (query.value.indexOf(' ') > -1)
+          query.value = bracketStr(query.value);
+        return strPrecedingQuery + query.type + ':' + query.value;
+      }
+
+      // cases below: 
+      // autocomplete, select from dropdown ... also blur when user types a keyword
+      // leaving the evental type label in the input box, adding autocompletition stuff
+      var cutOffIdx = getAutocompleteValueCutoffInd(typedText).withBrackets;
+      var strPrecedingQuery = typedText.substring(0, cutOffIdx);
+
+      // the case on blur after typing the whole keyword
+      if (lowercaseKeywords.indexOf(value.toLowerCase()) > -1) {
+        return strPrecedingQuery + value;  
+      }
+
+      // autocompletition with a value containing spaces
+      // (in keywords spaces can be only at the end - which is the previous case)
+      if (value.indexOf(' ') > -1) {
+        value = bracketStr(value);
+      }
+
+      return strPrecedingQuery + value; 
+    }
+
+    field.typeahead({
+      local: keywords,
+      remote: {
+        url: '/list/%TYPE?q=%QUERY',
+        
+        replace: function(url, uriEncodedQuery) {
+
+          var query = parseQuery(uriEncodedQuery, '%3A')
+
+          url = url.replace('%TYPE', autocompleteTypeKeys[query.type]);
+          url = url.replace('%QUERY', query.value);
+
+          // console.log('server query: ' + url);
+
+          return url;
+        },
+
+        filter: function(response) {
+          return response.results;
+        }
+
+      },
+      name: 'search',
+      limit: 10
+    });
+
+    var orgTypeahead = {
+      setInputValue: field.data("ttView").inputView.setInputValue,
+      getQuery: field.data("ttView").inputView.getQuery,
+      getSuggestions: field.data('ttView').datasets[0].getSuggestions
+    };
+
+    field.data("ttView").inputView.getQuery = function() {
+
+      return getQuery(orgTypeahead.getQuery());
+    }
+
+    field.data("ttView").inputView.setInputValue = function(value, silent) {
+
+      var typedText = this.$input.val();
+      var merged = mergeWithInputValue(value, typedText);
+      return orgTypeahead.setInputValue.apply(field.data("ttView"), [merged, silent]);
+    }
+
+    var dataset = field.data('ttView').datasets[0];
+
+    dataset.getSuggestions = function(query, cb) { 
+
+      var parsedQuery = parseQuery(query);
+
+      // console.log(parsedQuery.value + "++++" + parsedQuery.type);
+
+      // eventually remove the quotation mark
+      if (parsedQuery.value[0] == '"') // '"'
+      {
+          parsedQuery.value = parsedQuery.value.substring(1, parsedQuery.value.length);
+          query = parsedQuery.type + ':' + parsedQuery.value;
+      }
+
+      if (parsedQuery.type == "KWORD")
+      {
+        // a hack to disable remote queries 
+        // there's an "if" to check "transport" existence
+        // inside original getSuggestions() function
+        var transportCopy = dataset.transport;
+        dataset.transport = 0;
+        var result = orgTypeahead.getSuggestions(query, cb);
+        dataset.transport = transportCopy;
+        return result;
+      }
+
+      // do the remote query only if the type is valid and query length
+      // is at least 3 - which is also a server requirement
+      if (parsedQuery.type in autocompleteTypeKeys && typeof(autocompleteTypeKeys[parsedQuery.type]) == 'string' && parsedQuery.value.length > 2) {
+
+        // the same hack as above to disable the local queries
+        var localCopy = dataset.local;
+        dataset.local = [];
+        var result = orgTypeahead.getSuggestions(query, cb);
+        dataset.local = localCopy;
+        return result;
+      }
+    }
   }
 
-  $.fn.searchTypeahead.defaults = $.fn.typeahead.defaults
-  $.fn.searchTypeahead.Constructor = SearchTypeahead
+  $.fn.searchTypeahead = SearchTypeahead;
 
 }( window.jQuery )

--- a/invenio/modules/search/templates/search/admin_helpers.html
+++ b/invenio/modules/search/templates/search/admin_helpers.html
@@ -22,7 +22,7 @@
 {% macro collection_tree(collection, children ) %}
 
 <ul class="nav nav-list">
-  <li class="nav-header">{{ collection.name }}</li>
+  <li class="dropdown-header">{{ collection.name }}</li>
   <li>
   <ul {{ kwargs|xmlattr }}  data-id="{{ collection.id }}">
     {% for c in collection|attr(children)|sort(attribute='score') recursive %}

--- a/invenio/modules/search/templates/search/admin_index.html
+++ b/invenio/modules/search/templates/search/admin_index.html
@@ -73,28 +73,28 @@
 </div>
 
 <div class="row">
-  <div style="min-height: 30px; padding: 10px;" class="trash droppable connectedSortable span8" data-id="0">
-    <i class="icon icon-trash"></i> {{ _('Drop here to delete.') }}
+  <div style="min-height: 30px; padding: 10px;" class="trash droppable connectedSortable col-md-8" data-id="0">
+    <i class="glyphicon glyphicon-trash"></i> {{ _('Drop here to delete.') }}
   </div>
 </div>
 
 
 <div class="row">
-  <div class="span4 collection">
+  <div class="col-md-4 collection">
     <h4>{{ _("Narrow by collections") }}</h4>
     {{ collection_tree(collection, '_collection_children_r', class="nav nav-list sortable
     connectedSortable" ) }}
   </div>
 
-  <div class="span4 collection">
+  <div class="col-md-4 collection">
 	  <h4>{{ _("Focus on") }}</h4>
     {{ collection_tree(collection, '_collection_children_v', class="nav nav-list sortable
     connectedSortable") }}
   </div>
 
-  <div class="span4 collection">
+  <div class="col-md-4 collection">
     <ul class="nav nav-list">
-      <li class="nav-header">{{ _('Orphans') }}</li>
+      <li class="dropdown-header">{{ _('Orphans') }}</li>
       <li>
         <ul class="nav nav-list draggable" data-id="0" data-len="{{ orphans|length() }}" >
       {% if orphans %}

--- a/invenio/modules/search/templates/search/browse.html
+++ b/invenio/modules/search/templates/search/browse.html
@@ -36,7 +36,7 @@
   {{ portalboxes.te }}
 {% endblock %}
 {% block header %}
-  {{ super() }}
+  {{ super() }} 
   {% js url_for('search.static', filename='js/search/typeahead.js') %}
   {% js url_for('search.static', filename='js/search/facet.js') %}
   {% js url_for('static', filename='js/bootstrap-select.js') %}
@@ -79,7 +79,7 @@ body {
 {% if not records|length %}
 
 <div class="row">
-  <div class="span12">
+  <div class="col-md-12">
     <p>
       <strong>{{ _('Your search did not match any records. Please try again.') }}</strong>
     </p>
@@ -90,7 +90,7 @@ body {
 {% else %}
 
 <div class="row">
-  <div class="span12">
+  <div class="col-md-12">
     <table class="table table-striped table-hover">
       <tr>
         <th style="width: 20%">{{ _('Hits') }}</th>

--- a/invenio/modules/search/templates/search/helpers.html
+++ b/invenio/modules/search/templates/search/helpers.html
@@ -65,7 +65,7 @@
     <a href="{{ url_for('comments.comments', recid=recID) }}"
        data-hotkey-action="click"
        data-hotkey-value="g{{ i }}c">
-      <i class="icon-comment"></i>
+      <i class="glyphicon glyphicon-comment"></i>
       {{ _("%i comments") % num_comments if num_comments > 1 else _("1 comment") }}
     </a>
     {%- endif -%}
@@ -77,7 +77,7 @@
     {%- if num_reviews -%}
      -
     <a href="{{ url_for('comments.reviews', recid=recID) }}">
-      <i class="icon-eye-open"></i>
+      <i class="glyphicon glyphicon-eye-open"></i>
       {{ _("%i reviews") % num_reviews if num_reviews > 1 else _("1 review") }}
     </a>
     {%- endif -%}
@@ -99,7 +99,7 @@
     <a href="{{ url_for(".collection", name=collection.name, ln=g.ln, _external=True) }}">
       {{ collection.name_ln }}
     </a>
-    <small class="muted">({{ collection.nbrecs }})</small>&nbsp;
+    <small class="text-muted">({{ collection.nbrecs }})</small>&nbsp;
   {% if collection.collection_children and idxs|length < limit %}
     {%- do idxs.append(loop.index) -%}
     <ul {{ kwargs|xmlattr }}>
@@ -115,16 +115,14 @@
 {% macro portalbox_sidebar(portalboxes, width=2) %}
   {% if portalboxes %}
   <div {{ kwargs|xmlattr }}>
-    <ul class="thumbnails">
     {% for cp in portalboxes %}
-    <li class="span{{ width }}">
-    <div class="thumbnail">
-      <h5>{{ cp.portalbox.title }}</h5>
-      <p>{{ cp.portalbox.body|safe }}</p>
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <h5>{{ cp.portalbox.title }}</h5>
+        <p>{{ cp.portalbox.body|safe }}</p>
+      </div>
     </div>
-    </li>
     {% endfor %}
-    </ul>
   </div>
   {% endif %}
 {% endmacro %}
@@ -154,144 +152,154 @@
 
 
 {% macro _search_simple_box(collection) %}
-  {% for f in easy_search_form if not f.name=='csrf_token' %}
-  <div class="control-group">
-    <label class="control-label">
-      {{ f.label.text }}
-    </label>
-    <div class="controls controls-row">
-      {{ f|safe }}
+    {% for f in easy_search_form if not f.name=='csrf_token' %}
+    <div class="form-group">
+      <label class="col-md-2 col-sm-3 control-label">
+        {{ f.label.text }}
+      </label>
+      <div class="col-md-10 col-sm-9">
+        {{ f(class_='form-control')|safe }}
+      </div>
     </div>
-  </div>
-  {% endfor %}
+    {% endfor %}
+
+    <div class="form-group">
+      <div class="col-md-offset-2 col-md-10 col-sm-offset-3 col-sm-9">
+        <div class="pull-right">
+          <button name="action_browse" class="btn">
+            <i class="glyphicon glyphicon-list"></i> {{ _("Browse") }}
+          </button>
+          <button name="action_search" type="submit" class="btn btn-primary">
+            <i class="glyphicon glyphicon-search"></i> {{ _("Search") }}
+          </button>
+        </div>
+      </div>
+    </div>
 {% endmacro %}
 
 
 {% macro _search_advanced_box(collection) %}
-
-  <div class="control-group">
-    <label class="control-label">
-      <strong>{{ _('what') }}?</strong>
-    </label>
-    <div class="controls">
-      <input type="text" name="p1" value="" class="span3"/>
+    <div class="form-group">
+      <label class="col-sm-3 col-md-2 control-label">
+        {{ _('what') }}?
+      </label>
+      <div class="col-sm-9 col-md-10">
+        <input type="text" name="p1" value="" class="form-control"/>
+      </div>
     </div>
-  </div>
 
-  <div class="control-group">
-    <label class="control-label">
-      <strong>{{ _('where') }}?</strong>
-    </label>
-    <div class="controls">
-    <select class="span2" name="f">
-      {% for (code, name) in collection.search_within %}
-      <option value="{{ code }}">
-        {{ name }}
-      </option>
-      {% endfor %}
-    </select>
+    <div class="form-group">
+      <label class="col-sm-3 col-md-2 control-label">
+        {{ _('where') }}?
+      </label>
+      <div class="col-sm-9 col-md-10">
+        <select class="form-control" name="f">
+          {% for (code, name) in collection.search_within %}
+          <option value="{{ code }}">
+            {{ name }}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
     </div>
-  </div>
 
-  <div class="control-group">
-    <label class="control-label">
-      <strong>{{ _('how') }}?</strong>
-    </label>
-    <div class="controls">
-      <select class="span2" name="m1">
-        {%- for v in config.CFG_WEBSEACH_MATCHING_TYPES|sort(attribute='order') -%}
-          <option value="{{ v.code }}">{{ _(v.title)|safe }}</option>
-        {%- endfor -%}
-      </select>
-    <span id="addtosearch" class="btn">
-      <i class="icon-ok"></i>
-    </span>
+    <div class="form-group">
+      <label class="col-sm-3 col-md-2 control-label">
+        {{ _('how') }}?
+      </label>
+      <div class="col-sm-9 col-md-10">
+        <select name="m1" class="form-control">
+          {%- for v in config.CFG_WEBSEACH_MATCHING_TYPES|sort(attribute='order') -%}
+            <option value="{{ v.code }}">{{ _(v.title)|safe }}</option>
+          {%- endfor -%}
+        </select>
+      </div>
     </div>
-  </div>
 
-  {% for id, soo in collection.search_options|groupby('id_field') %}
-  <hr/>
-  <div class="control-group">
-    <label class="control-label">{{ soo[0].field.name_ln }}</label>
-    <div class="controls">
-    <select class="span2" name="{{ soo[0].field.code }}">
-      <option value="">*** {{ _('select') }} ***</option>
-      {% for so in soo %}
-      <option value="{{ so.fieldvalue.value }}">
-        {{ so.fieldvalue.name }}
-      </option>
-      {% endfor %}
-    </select>
-    <span data-target="p" data-source="{{ soo[0].field.code }}" class="btn appender">
-      <i class="icon-ok"></i>
-    </span>
+    {% for id, soo in collection.search_options|groupby('id_field') %}
+    <hr/>
+    <div class="form-group">
+      <label class="control-label col-sm-3 col-md-2">{{ soo[0].field.name_ln }}</label>
+      <div class="col-sm-9 col-md-10">
+        <div class="input-group">
+          <select class="form-control" name="{{ soo[0].field.code }}">
+            <option value="">*** {{ _('select') }} ***</option>
+            {% for so in soo %}
+            <option value="{{ so.fieldvalue.value }}">
+              {{ so.fieldvalue.name }}
+            </option>
+            {% endfor %}
+          </select>
+          <span data-target="p" data-source="{{ soo[0].field.code }}" class="btn appender">
+            <i class="glyphicon glyphicon-ok"></i>
+          </span>
+        </div>
+      </div>
     </div>
-  </div>
-  {% endfor %}
+    {% endfor %}
+
+    <div class="form-group">
+      <div class="col-md-offset-2 col-md-10 col-sm-offset-3 col-sm-9">
+        <div class="pull-left">
+          <button id="addtosearch" class="btn">
+            <i class="glyphicon glyphicon-plus"></i> {{ _("Add to search") }}
+          </button>
+        </div>
+        <div class="pull-right">
+          <button name="action_browse" class="btn">
+            <i class="glyphicon glyphicon-list"></i> {{ _("Browse") }}
+          </button>
+          <button name="action_search" type="submit" class="btn btn-primary">
+            <i class="glyphicon glyphicon-search"></i> {{ _("Search") }}
+          </button>
+        </div>
+      </div>
+    </div>
 
 {% endmacro %}
 
 {% macro search_box(collection) %}
-  <div style="padding: 0px;" class="dropdown-menu donothide">
-    <div class="row">
-      <div class="span6" style="min-width: 400px;">
+  <div class="form-horizontal add_to_search-form">
+    <div class="form-group _tab-form-group">
+      <label class="col-sm-3 col-md-2 control-label">
+        {{ _('Add to search') }}
+      </label>
+      <div class="col-md-10 col-sm-9" data-toggle="buttons">
+        <div class="btn-group pull-left" id="add_type-btn-group" data-toggle="buttons">
+          <label class="btn btn-sm btn-default active">
+            <input type="radio" name="op1" value="a" active/>{{ _('AND') }}
+          </label>
+          <label class="btn btn-sm btn-default">
+            <input type="radio" name="op1" value="o"/>{{ _('OR') }}
+          </label>
+          <label class="btn btn-sm btn-default">
+            <input type="radio" name="op1" value="n"/>{{ _('AND NOT') }}
+          </label>
+        </div>
 
-        <div class="modal-header">
-          <button type="button" style="z-index:9999; position: relative;" class="close" onclick="$('.dropdown').removeClass('open open-permanent')">×</button>
-          <div class="control" style="margin-bottom: 0px;">
-            <label class="control-label">
-              <strong>{{ _('Add to search') }}</strong>
-            </label>
-            <div class="controls">
-            <div style="padding-top:4px;" class="btn-group" data-toggle="buttons-radio">
-              <label class="btn btn-mini active">
-                <input style="display:none;" type="radio" name="op1" value="a" checked/>{{ _('AND') }}
-              </label>
-              <label class="btn btn-mini">
-                <input style="display:none;" type="radio" name="op1" value="o"/>{{ _('OR') }}
-              </label>
-              <label class="btn btn-mini">
-                <input style="display:none;" type="radio" name="op1" value="n"/>{{ _('AND NOT') }}
-              </label>
-            </div>
-            </div>
-          </div>
-        </div><!-- end modal-header-->
-
-        <div style="max-height: 800px;" class="modal-body">
-
-<div class="tab-content">
-  <div class="tab-pane active" id="simple-search">
-    {{ _search_simple_box(collection) }}
-  </div>
-  <div class="tab-pane" id="advanced-search">
-    {{ _search_advanced_box(collection) }}
-  </div>
-</div>
-
-
-        </div><!-- end modal-body -->
-
-        <div class="modal-footer">
-          <small><ul class="nav nav-pills nav-pill-gray pull-left" style="margin-bottom: 0px; text-align: left;">
+        <div class="pull-right">
+          <ul class="nav nav-tabs pull-right tab-buttons">
             <li class="active">
-              <a href="#simple-search" data-toggle="tab">{{ _('simple') }}</a>
+              <a href="#simple-search" id="simple-search-tab-button" data-toggle="tab">{{ _('simple') }}</a>
             </li>
             <li>
-              <a href="#advanced-search" data-toggle="tab">{{ _('advanced') }}</a>
+              <a href="#advanced-search" id="advanced-search-tab-button" data-toggle="tab">{{ _('advanced') }}</a>
             </li>
-          </ul></small>
-          <button name="action_browse" class="btn">
-            <i class="icon-list"></i> {{ _("Browse") }}
-          </button>
-          <button name="action_search" type="submit" class="btn btn-primary">
-            <i class="icon-search icon-white"></i> {{ _("Search") }}
-          </button>
-        </div><!-- end modal-footer -->
+          </ul>
+        </div>
+      </div>
 
-      </div><!-- end span5 -->
-    </div><!-- end row -->
-  </div><!-- end dropdown-menu -->
+    </div>
+
+    <div class="tab-content">
+      <div class="tab-pane active" id="simple-search">
+        {{ _search_simple_box(collection) }}
+      </div>
+      <div class="tab-pane" id="advanced-search">
+        {{ _search_advanced_box(collection) }}
+      </div>
+    </div>
+  </div>
 
 <style>
 .nav.nav-pill-gray > .active > a,
@@ -301,281 +309,350 @@
   color: inherit;
 }
 
-#searchdropdown .searchexamples i.pull-right {
-  margin-right: -6px;
-  margin-top: 3px;
-  opacity: .25;
+/* line below the tab bar */
+
+._tab-form-group {
+  border-bottom: 1px solid #e7e7e7;
 }
 
-#searchdropdown .searchexamples .after-fix {
-  padding-right: 20px;
+._tab-form-group .nav-tabs {
+  border-bottom: none;
 }
 
-.open-permanent .donothide {
-  display: block!important;
-}
+/* ----------------------- */
+
 
 </style>
 {% endmacro %}
 
-{% macro search_form(collection) %}
-  <div id="search-box-main" class="row">
-    <div class="span12">
-    <div class="well well-small"
-         style="margin-bottom: 20px; margin-left: -9px; margin-right: -9px;">
-      <div class="row">
+{% macro searchsettings_form(collection) %}
 
-        <form action="{{ url_for('search.search') }}" name="settings" method="get"
-              style="margin-bottom: 0px; position: relative; z-index: 1;"
-              class="pull-right form-inline">
-          <input name="p" value="{{ request.args.get('p','') }}" type="hidden" />
-
-
-        <div id="settingsdropdown" class="pull-right btn-group dropdown">
-          <button class="btn dropdown-toggle add-open-permanent" data-target="#settingsdropdown" data-toggle="dropdown">
-            <i class="icon-cog"></i>
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu donothide clearfix"
-              style="min-width: 300px; padding-bottom: 0px;">
-            <li class="nav-header">{{ _('Search settings') }}</li>
-
-            <li class="divider"></li>
-            <li class="clearfix nav-list">
-
-          <div class="control-group clearfix">
-            <label class="control-label pull-left">{{ _('Display on page') }}</label>
-            <div class="controls pull-right">
-              <select
-                      name="rg"
-                      style="height: inherit; line-height: inherit;"
-                      class="btn-small span2">
-              {%- for i in [10, 25, 50, 100, 250, 500] -%}
-              {%- if i <= config.CFG_WEBSEARCH_MAX_RECORDS_IN_GROUPS -%}
-                <option value="{{ i }}"{{ ' selected' if request.args.get('rg',10)==i.__str__() }}>{{ i }} {{ _('results') }}</option>
-              {%- endif -%}
-              {%- endfor -%}
-              </select>
-            </div>
-          </div>
-
-
-          <div class="control-group clearfix">
-            <label class="control-label pull-left">{{ _('Output format') }}</label>
-            <div class="controls pull-right">
-              <select
-                      name="of"
-                      style="height: inherit; line-height: inherit;"
-                      class="btn-small span2">
-              {%- for i in collection.formatoptions if i.content_type == 'text/html' and i.visibility == 1 -%}
-                <option value="{{ i.code }}"{{ ' selected' if request.args.get('of','hb')==i.code }}>{{ i.name }}</option>
-              {%- endfor -%}
-              </select>
-            </div>
-          </div>
-
-          {% if collection.rnkMETHODs|length %}
-          <div class="control-group clearfix">
-            <label class="control-label pull-left">{{ _('Ranking') }}</label>
-            <div class="controls pull-right">
-              <select name='rm'
-                      style="height: inherit; line-height: inherit;"
-                      class="btn-small span2">
-              {% for rnk_method in collection.rnkMETHODs %}
-                <option value="{{ rnk_method.rnkMETHOD.name }}">
-                  {{ rnk_method.rnkMETHOD.get_name_ln() }}
-                </option>
-              {% endfor %}
-              </select>
-            </div>
-          </div>
-          {% endif %}
-
-          <div class="clearfix">
-            <label class="control-label pull-left">{{ _('Sort by most') }}</label>
-            <div class="controls pull-right">
-            <div class="btn-group" data-toggle="buttons-radio">
-            {%- for (k,v,vv) in [('recent', 'rm', ''), ('cited', 'rm', 'citation'), ('relevant', 'rm', 'wrd')] -%}
-              <label class="btn btn-mini {{ 'active' if request.args.get(v,'') == vv}}">
-                <input style="display:none;"
-                  type="radio"
-                  name="{{ v }}"
-                  value="{{ vv }}"
-                  {{ 'checked="checked"'|safe if request.args.get(v,'') == vv}}>
-                {{ _(k) }}
-              </label>
-            {%- endfor -%}
-            </div>
-            </div>
-          </div>
-
-            </li>
-
-            <li class="divider"></li>
-            <li class="clearfix nav-list">
-            <div class="control-group clearfix">
-              <label class="control-label pull-left">{{ _('Search form') }}</label>
-            <div class="controls pull-right">
-            <div class="btn-group" data-toggle="buttons-radio">
-            {%- for (k,v) in [(_('Simple'), 'simple'), (_('Advanced'), 'advanced')] -%}
-              {%- set active = v=='simple' -%}
-              <label class="btn btn-mini">
-                <input style="display:none;"
-                  type="radio"
-                  name="box"
-                  value="{{ v }}"
-                  {{ 'checked="checked"'|safe if active}}>
-                {{ k }}
-              </label>
-            {%- endfor -%}
-            </div>
-            </div>
-            </div>
-            </li>
-
-            <li class="modal-footer nav-list clearfix">
-              {%- if not current_user.is_guest -%}
-              <button name="action_save"
-                      rel="tooltip"
-                      title="{{ _('store permanently in user settings') }}"
-                      data-placement="bottom"
-                      class="btn btn-primary btn-small pull-left">
-                <i class="icon-hdd icon-white"></i> {{ _('Save') }}
-              </button>
-              {%- endif -%}
-              <button name="action_search"
-                      rel="tooltip"
-                      title="{{ _('use settings in current search') }}"
-                      data-placement="bottom"
-                      class="btn btn-small pull-right">
-                <i class="icon-ok"></i> {{ _('Apply') }}
-              </button>
-            </li>
-          </ul>
-        </div>
-        </form>
-
-
-
-        <form action="{{ url_for('search.search') }}"
-              name="search"
-              method="get"
-              style="margin-bottom: 0px;"
-              class="form-horizontal span11">
-        <div class="row">
-          <div class="span2 visible-desktop">
-            <label for="p"
-                style="padding-top: 5px; text-align: right; font-size: 90%;">
-              {%- set nbrecs = collection.nbrecs -%}
-              {%- if not collection.nbrecs -%}
-              {%- set nbrecs = 0 -%}
-              {%- endif -%}
-              {{ _("Search %s records for")|format(nbrecs) }}
-            </label>
-          </div>
-          <div class="span9">
-            <div id="searchdropdown"
-                 class="dropdown">
-            {#
-            {% set search_placeholder = _('Input query') %}
-            {% if collection.examples %}
-              {% set search_placeholder = (collection.examples|random).body %}
-            {% endif %}
-            #}
-              <div class="input-prepend input-append">
-                <div class="dropdown add-on">
-                  <a class="dropdown-toggle"
-                     rel="tooltip" title="{{ _('Search Tips and Examples') }}"
-                     data-placement="bottom"
-                     data-delay="100"
-                     data-toggle="dropdown" role="button"
-                     href="#"><i class="icon-question-sign"></i></a>
-                  <ul class="searchexamples dropdown-menu" style="text-align: left;">
-                    <li>
-                      <a href="/help/search-tips">
-                        <i class="pull-right icon-info-sign"></i>
-                        <strong>{{ _("Search Tips") }}</strong>
-                      </a>
-                    </li>
-                    <li>
-                      <a href="/help/search-guide">
-                        <i class="pull-right icon-leaf"></i>
-                        <strong>{{ _("Search Guide") }}</strong>
-                      </a>
-                    </li>
-                    {% if collection.examples %}
-                    <li class="divider"></li>
-                    <li class="nav-header">
-                      {{ _('Search examples') }}
-                    </li>
-                  {%- for e in collection.examples if e.body -%}
-                    <li>
-                      <a href="{{ url_for('search.search', p=e.body) }}">
-                        <i class="pull-right icon-chevron-right"></i>
-                        <span class="after-fix">{{ e.body }}</span>
-                      </a>
-                    </li>
-                  {%- endfor -%}
-                  {% endif %}
-                  </ul>
-                </div><!--
-                No space!
-             --><input autocomplete="off"
-                  data-provide="typeahead"
-                  data-items="4"
-                  name="p"
-                  class="span6"
-                  type="text"
-                  style="min-width:200px;"
-                  {# placeholder="{{ _('Example') }}: {{ search_placeholder }}" #}
-                  tabindex="1"
-                  value="{{ request.args.get('p', '') }}"
-                  {%- if request.endpoint == 'search.index' -%}
-                  autofocus
-                  {%- endif -%}
-                  /><!--
-                No space!
-             --><span data-toggle="dropdown" data-target="#searchdropdown" class="add-on btn add-open-permanent">
-                  <i class="caret"></i>
-                </span>
-              </div>
-
-{#
- # This is a dirty hack for browser without Javascript support.
- #}
-<script type="text/javascript">
-  var box = {{ search_box(collection)|tojson|safe }};
-  document.write(box);
-</script>
-
-              <!-- Hidden configuration fields -->
-              {% if collection.id != 1 %}
-              <input type="hidden" name="cc" value="{{ collection.name }}" />
-              {% endif %}
-              {{ _search_hidden_options() }}
-              <!-- end of configuration fields -->
-
-              <button name="action_search" type="submit" class="btn btn-primary">
-                <i class="icon-search icon-white"></i>
-                <span class="hidden-phone">{{ _("Search") }}</span>
-              </button>
-              {#
-              <span class="help-inline">
-                <a href="/help/search-tips">{{ _("Search Tips") }}</a>
-              </span>
-              #}
-            </div>
-          </div><!-- end controls -->
-        </div>
-        </form>
-
-      </div><!-- end sub row -->
-    </div><!-- end span12 -->
+  <form action="{{ url_for('search.search') }}" 
+    name="settings" 
+    method="get"
+    class="form-horizontal">
+    <div class="row">
+    <input name="p" value="{{ request.args.get('p','') }}" type="hidden" />
+    <div class="form-group col-md-6">
+      <label class="control-label col-sm-6 col-xs-5">{{ _('Display on page') }}</label>
+      <div class="col-sm-6 col-xs-7">
+        <select
+          name="rg"
+          class="btn-sm form-control">
+          {%- for i in [10, 25, 50, 100, 250, 500] -%}
+            {%- if i <= config.CFG_WEBSEARCH_MAX_RECORDS_IN_GROUPS -%}
+              <option value="{{ i }}"{{ ' selected' if request.args.get('rg',10)==i.__str__() }}>{{ i }} {{ _('results') }}</option>
+            {%- endif -%}
+          {%- endfor -%}
+        </select>
+      </div>
     </div>
-  </div><!-- end row -->
+
+    <div class="form-group col-md-6">
+    <label class="control-label col-sm-6 col-xs-5">{{ _('Output format') }}</label>
+    <div class="col-sm-6 col-xs-7">
+      <select
+              name="of"
+              class="btn-sm form-control">
+      {%- for i in collection.formatoptions if i.content_type == 'text/html' and i.visibility == 1 -%}
+        <option value="{{ i.code }}"{{ ' selected' if request.args.get('of','hb')==i.code }}>{{ i.name }}</option>
+      {%- endfor -%}
+      </select>
+    </div>
+  </div>
+
+  {% if collection.rnkMETHODs|length %}
+  <div class="form-group col-md-6">
+    <label class="control-label col-sm-6 col-xs-5">{{ _('Ranking') }}</label>
+    <div class="btn-group col-sm-6 col-xs-7">
+      <select name='rm'
+              class="btn-xs form-control">
+      {% for rnk_method in collection.rnkMETHODs %}
+        <option value="{{ rnk_method.rnkMETHOD.name }}">
+          {{ rnk_method.rnkMETHOD.get_name_ln() }}
+        </option>
+      {% endfor %}
+      </select>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="form-group col-md-6">
+    <label class="control-label col-sm-6 col-xs-5">{{ _('Sort by most') }}</label>
+    <div class="btn-group col-sm-6 col-xs-7" data-toggle="buttons">
+    {%- for (k,v,vv) in [('recent', 'rm', ''), ('cited', 'rm', 'citation'), ('relevant', 'rm', 'wrd')] -%}
+      <label class="btn btn-sm btn-default {{ 'active' if request.args.get(v,'') == vv}}">
+        <input
+          type="radio"
+          name="{{ v }}"
+          value="{{ vv }}"
+          {{ 'checked="checked"'|safe if request.args.get(v,'') == vv}}>
+        {{ _(k) }}
+      </label>
+    {%- endfor -%}
+    </div>
+  </div>
+
+   <div class="form-group col-md-6">
+    <label class="col-sm-6 control-label col-xs-5">{{ _('Search form') }}</label>
+    <div class="btn-group col-sm-6 col-xs-7" data-toggle="buttons">
+      {%- for (k,v) in [(_('Simple'), 'simple'), (_('Advanced'), 'advanced')] -%}
+      {%- set active = v=='simple' -%}
+      <label class="btn btn-sm btn-default">
+        <input
+          type="radio"
+          name="box"
+          value="{{ v }}"
+          {{ 'checked="checked"'|safe if active}}>
+        {{ k }}
+      </label>
+      {%- endfor -%}
+    </div>
+  </div>
+  </div>
+
+  <div class="form-group col-md-6 pull-right">
+    {%- if not current_user.is_guest -%}
+    <button name="action_save"
+      rel="tooltip"
+      title="{{ _('store permanently in user settings') }}"
+      data-placement="bottom"
+      class="btn btn-primary btn-sm pull-left">
+      <i class="glyphicon glyphicon-hdd"></i> {{ _('Save') }}
+    </button>
+    {%- endif -%}
+    <button name="action_search"
+      rel="tooltip"
+      title="{{ _('use settings in current search') }}"
+      data-placement="bottom"
+      class="btn btn-sm pull-right">
+      <i class="glyphicon glyphicon-ok"></i> {{ _('Apply') }}
+    </button>
+  </div>
+  
+  </form>
+
+{% endmacro %}
+
+{% macro search_form(collection) %}
+  <style>
+
+    #search-label {
+      font-size: 14px;
+    }
+
+    /* -------------- */
+
+    /* 
+    to make "add to search" form look consistent
+    in much shrinked window
+
+    values copied from bootstrap ones for higher than xs size counterparts -> to be unified using "less"
+    */
+
+    .navbar-collapse {
+      border-top: none;
+    }
+
+    .navbar-collapse .navbar-nav.navbar-left:first-child {
+      margin-left: -15px;
+    }
+
+    .navbar-form {
+      padding-top: 0;
+      padding-bottom: 0;
+      margin-right: 0;
+      margin-left: 0;
+      border: 0;
+    }
+
+    /* ------------ */
+
+    .navbar-row {
+      width: 100%;
+      margin: inherit;
+    }
+
+    .navbar-row .navbar-row-container {
+      /* same colour as navbar border*/
+      border-top: 1px solid #e7e7e7;
+      padding-top: 20px;
+      padding-bottom: 20px;
+    }
+
+    .navbar-collapse {
+      max-height: none;
+    }
+
+    /* 
+      somehow original bootstrap's -4px doesn't look good
+      and results in thick (double) borders around buttons
+    */
+    .input-group-btn > .btn + .btn,
+    .input-group-btn > .btn {
+      margin-left: -5px;
+    }
+
+    /*
+      too keep searchbar with buttons in one line
+    */
+    @media (min-width: 768px) { /* ld size */
+       #searchform-input-group {
+         width: 670px;
+       }
+    }
+
+    @media (min-width: 992px) { /* md size */
+       #searchform-input-group {
+         width: 710px;
+       }
+    }
+
+    @media (min-width: 1200px) { /* ld size */
+       #searchform-input-group {
+         width: 920px;
+       }
+    }
+
+    /* 
+      showing dropdown stil as dropdown
+      on shrinked window
+    */
+    @media (max-width: 767px) {
+      .navbar-nav .open .dropdown-menu {
+        position: absolute;
+        margin-top: 2px;
+        background-color: #ffffff;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+      }
+
+      .navbar-default .navbar-nav .open .dropdown-menu > li > a {
+        color: #333333;
+      }
+    }
+
+  </style>
+  <div id="search-box-main">
+    <nav class="navbar navbar-default" role="navigation">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <span class="navbar-brand hidden-sm hidden-xs" id="search-label">
+          {%- set nbrecs = collection.nbrecs -%}
+          {%- if not collection.nbrecs -%}
+          {%- set nbrecs = 0 -%}
+          {%- endif -%}
+          {{ _("Search %s records for")|format(nbrecs) }}
+        </span>
+      </div>
+
+      <!-- Collect the nav links, forms, and other content for toggling -->
+      <div class="navbar-collapse">
+        <ul class="nav navbar-nav navbar-right">
+          
+        </ul>
+        <form action="{{ url_for('search.search') }}"
+            name="search"
+            method="get"
+            role="search"
+            id="searchform">
+        <div class="nav navbar-nav navbar-left navbar-form">
+            <div class="input-group" id="searchform-input-group">
+              <span class="input-group-btn">
+                <a class="dropdown-toggle btn btn-default"
+                       rel="tooltip" title="{{ _('Search Tips and Examples') }}"
+                       data-placement="bottom"
+                       data-delay="100"
+                       data-toggle="dropdown" role="button"
+                       href="#"><i class="glyphicon glyphicon-question-sign"></i>
+                </a>
+                <ul class="searchexamples dropdown-menu">
+                  <li>
+                    <a href="/help/search-tips">
+                      <strong>{{ _("Search Tips") }}</strong>
+                      <i class="pull-right glyphicon glyphicon-info-sign"></i>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="/help/search-guide">
+                      <i class="pull-right glyphicon glyphicon-leaf"></i>
+                      <strong>{{ _("Search Guide") }}</strong>
+                    </a>
+                  </li>
+                  {% if collection.examples %}
+                  <li class="divider"></li>
+                  <li class="dropdown-header">
+                    {{ _('Search examples') }}
+                  </li>
+                {%- for e in collection.examples if e.body -%}
+                  <li>
+                    <a href="{{ url_for('search.search', p=e.body) }}">
+                      <i class="pull-right glyphicon glyphicon-chevron-right"></i>
+                      <span class="after-fix">{{ e.body }}</span>
+                    </a>
+                  </li>
+                {%- endfor -%}
+                {% endif %}
+                </ul>
+              </span>
+              <input autocomplete="off"
+                      data-items="4"
+                      name="p"
+                      class="form-control"
+                      type="text"
+                      {# placeholder="{{ _('Example') }}: {{ search_placeholder }}" #}
+                      tabindex="1"
+                      value="{{ request.args.get('p', '') }}"
+                      {%- if request.endpoint == 'search.index' -%}
+                      autofocus
+                      {%- endif -%}
+              /><!-- No space! -->
+              <span class="input-group-btn invenio-collapsable-tabs" data-toggle="buttons">
+                <a href="#" class="btn btn-default right-not-rounded left-not-rounded" data-toggle="collapse" data-target="#navbar-bottom">
+                  <i class="glyphicon glyphicon-plus"></i>
+                  <b class="caret"></b>
+                </a>
+                <a href="#" class="btn btn-default right-not-rounded left-not-rounded" data-toggle="collapse" data-target="#navbar-bottom2">
+                  <i class="glyphicon glyphicon-cog"></i>
+                  <b class="caret"></b>
+                </a>
+              </span>
+              <span class="input-group-btn">
+                <button name="action_search" type="submit" class="btn btn-primary btn-inline-icon-hide-sm">
+                  <i class="glyphicon glyphicon-search"></i><span>&nbsp;{{ _("Search") }}</span>
+                </button>
+              </span>
+            </div>
+        </div>
+        <div class="nav navbar-nav navbar-row">
+          <div id="navbar-bottom" class="collapse">
+            <div class="row navbar-row-container">
+              <div class="col-md-12">
+                <script type="text/javascript">
+                  var box = {{ search_box(collection)|tojson|safe }};
+                  document.write(box);
+                </script>
+              </div>
+            </div>
+          </div>
+        </div>
+        </form>
+        <div class="nav navbar-nav navbar-row">
+          <div id="navbar-bottom2" class="collapse">
+            <div class="row navbar-row-container">
+              <div class="col-md-12">
+                {{ searchsettings_form(collection) }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div><!-- /.navbar-collapse -->
+    </nav>
+
+  </div>
   {% for category, msg in get_flashed_messages(with_categories=True, category_filter=['websearch-after-search-form']) %}
   <div class="row">
-    <div class="span12">
+    <div class="col-md-12">
       {{ msg|safe }}
     </div>
   </div>
@@ -589,28 +666,53 @@
   $(function () {
 
     $("form[name=search]").submit(function() {
-      $('.donothide').remove();
+      $('.add_to_search-form').remove();
       return true; // ensure form still submits
     })
 
-    $('#settingsdropdown select[name="of"]').buttonSelect({
-      button: '<div class="btn btn-mini" />'
-    , span: '<span class="btn btn-mini" style="width: 80px;" />'
-    , next: '<i class="icon icon-chevron-right"></i>'
-    , prev: '<i class="icon icon-chevron-left"></i>'
+    // side buttons for results number field
+    $('form[name=settings] select[name="of"]').buttonSelect({
+      button: '<div class="btn btn-sm btn-default" />'
+    , span: '<span class="btn btn-sm btn-default" style="width: 100px;" />'
+    , next: '<i class="glyphicon glyphicon-chevron-right"></i>'
+    , prev: '<i class="glyphicon glyphicon-chevron-left"></i>'
     })
 
-    $('#settingsdropdown select[name="rg"]').buttonSelect({
-      button: '<div class="btn btn-mini" />'
-    , span: '<span class="btn btn-mini" style="width: 80px;" />'
-    , next: '<i class="icon icon-plus"></i>'
-    , prev: '<i class="icon icon-minus"></i>'
+    // side buttons for output format field
+    $('form[name=settings] select[name="rg"]').buttonSelect({
+      button: '<div class="btn btn-sm btn-default" />'
+    , span: '<span class="btn btn-sm btn-default" style="width: 100px;" />'
+    , next: '<i class="glyphicon glyphicon-plus"></i>'
+    , prev: '<i class="glyphicon glyphicon-minus"></i>'
     })
 
-    //if (!("autofocus" in $("form[name=search] input[name=q]"))) {
+    // if (!("autofocus" in $("form[name=search] input[name=q]"))) {
     //  // ensure we get the focus always in search input
     //  $("form[name=search] input[name=q]").focus();
-    //}
+    // }
+
+    //--------------------
+
+    var radio_checkbox_hybrid = function (radioButtons) {
+
+      /*
+        Allows to deactivate a toggle buttons (like checkbuttons)
+        and make them behave as radio ones when the another one is clicked
+
+        @param radioButtons jQuerySelector for all the buttons in a group
+      */
+   
+      radioButtons.click(function () {
+        var buttons = $(this).siblings();
+        if (buttons.hasClass("active")) {
+          buttons.click();
+        }
+      });
+    }
+
+    radio_checkbox_hybrid($(".invenio-collapsable-tabs a"))
+
+    //---------------------
 
     var op1_fn = {'a': 'AND ', 'o': 'OR ', 'n': 'AND NOT '},
         m1_fn = {
@@ -622,7 +724,7 @@
         };
 
     var addtosearch_callback = function(e) {
-      var op1 = $('[name=op1]:checked').val(),
+      var op1 = $('#add_type-btn-group .active').children(':first').val(),
           m1 = $('[name=m1]').val(),
           p1 = $('[name=p1]').val(),
           f = $('[name=f]').val(),
@@ -647,7 +749,7 @@
         // get values
         var p = $('[name=p]'),
             val = $.trim(p.val()),
-            op1 = $('[name=op1]:checked').val(),
+            op1 = $('#add_type-btn-group .active').children(':first').val(),
             op = (op1=='a' && val=="")?'':op1_fn[op1],
             author = $('#author').val(),
             title = $('#title').val(),
@@ -678,28 +780,27 @@
         //query = query.replace(/topcite (\d+)?\+/, 'topcite $1->99999');
         //query = query.replace(' and ', ' ');
         //query = query.replace(/ /g, '+');
-        //window.location = search_url;
+        // window.location = search_url;
         if (query.length > 0) {
           p.val(val+query.join(' '+op1_fn[op1]));
         }
     };
 
-    $('.donothide .btn-primary').on('click', function(e) {
-      if ($('.modal-footer li.active a').attr('href') === '#simple-search') {
+    $('.add_to_search-form button[name=action_search]').on('click', function(e) {
+      if ($('.add_to_search-form .tab-buttons li.active a').attr('href') === '#simple-search') {
         perform_easy_search();
       } else {
         addtosearch_callback(e);
-        $('#searchdropdown .appender').trigger('click');
+        $('.add_to_search-form .appender').trigger('click');
       }
     });
 
     $('form[name=search] button[name=action_browse]').on('click', function(e) {
-      $('form[name=search] button[name=action_search]')
-        .attr('name', 'action_browse');
-      $('.donothide .btn-primary').trigger('click');
+      $('form[name=search] button[name=action_search]').attr('name', 'action_browse');
+      $('.add_to_search-form button[name=action_search]').trigger('click');
     });
 
-    $('#advanced-search #addtosearch').on('click', addtosearch_callback);
+    $('#addtosearch').on('click', addtosearch_callback);
     $('#advanced-search [name=p1]').keypress(function(event) {
       if ( event.which == 13 ) {
         if ($(this).val() !== '') {
@@ -709,8 +810,8 @@
       }
     });
 
-    $('#searchdropdown #advanced-search .appender').on('click', function(e) {
-        var op1 = $('[name=op1]:checked').val(),
+    $('.add_to_search-form #advanced-search .appender').on('click', function(e) {
+        var op1 = $('#add_type-btn-group .active').children(':first').val(),
             btn = $(this),
             source = $('[name='+btn.attr('data-source')+']'),
             target = $('[name='+btn.attr('data-target')+']'),
@@ -728,89 +829,65 @@
         return false;
     });
 
-    $('.add-open-permanent').on('click', function(e) {
-      $(this).parents('.dropdown').addClass('open-permanent')
-    })
 
-    $(document).on('click', function(e) {
-      if ($(e.target).parents('.donothide').length <= 0) {
-        $('.open-permanent').removeClass('open-permanent')
-      }
-    })
+    // -------------- SEARCH FIELD TYPEAHEAD ----------------
 
     var source = $.map({{ collection.search_within[1:]|tojson|safe }},
           function(val, i) { return val[0]+':';}); //['author:', 'title:', 'isbn:'];
+
+    var autocompleteQueriesType = {};
+
+    // keys existence in this dict is needed for autocompletition
+    for (var i in source) {
+      var key = source[i]
+      if (key[key.length - 1] == ':')
+        key = key.substring(0, key.length - 1);
+      autocompleteQueriesType[key] = undefined;
+    }
+
+    autocompleteQueriesType['author'] = 'exactauthor';
+
     source.push('AND ');
     source.push('OR ');
     source.push('AND NOT ');
 
-    var sources = {
     {% for id, soo in collection.search_options|groupby('id_field') %}
-      '{{ soo[0].field.code }}': [{% for so in soo %}
-            '{{ so.fieldvalue.name }}' {{ ',' if not loop.last }}
-            {% endfor %}
-        ]{{ ',' if not loop.last }}
-    {% endfor %}
-    };
-
-    {% for id, soo in collection.search_options|groupby('id_field') %}
-    source.push('{{ soo[0].field.code }}:');
+      source.push('{{ soo[0].field.code }}:');
     {% endfor %}
 
-    sources['author'] = function(query) {
-            var typeahead = this
-            $.ajax({
-              type: 'GET',
-              url: '{{ url_for('search.autocomplete', field='exactauthor') }}',
-              data: $.param({
-                q: query.substr(query.lastIndexOf(':')+1)
-              })
-            }).done(function(data) {
-              var a = [query.substr(query.lastIndexOf(':')+1)]
-                , b = data.results
-                , c = a.concat(b)
-              typeahead.process(c)
-            }).fail(function(data) {
-              var a = [query.substr(query.lastIndexOf(':')+1)]
-              typeahead.process(a)
-            })
-          };
+    // autocompleteQueriesType = {
+    // {% for id, soo in collection.search_options|groupby('id_field') %}
+    //   '{{ soo[0].field.code }}': [{% for so in soo %}
+    //         '{{ so.fieldvalue.name }}' {{ ',' if not loop.last }}
+    //         {% endfor %}
+    //     ]{{ ',' if not loop.last }}
+    // {% endfor %}
+    // };
+    //
 
+    var searchField = $('form[name=search] input[name=p]');
 
+    searchField.searchTypeahead(autocompleteQueriesType, source);
 
-    $('form[name=search] input[name=p]').searchTypeahead({
-      source: source,
-      sources: sources,
-      type: 'search'
+    
+    // END -------------- SEARCH TYPEAHEAD -------------- END
+
+    // ------------ typehead for "Add to search" form ----------------
+
+    $('[data-provide="typeahead-url"]').each(function (i, field) {
+      field = $(field);
+      field.typeahead({
+        prefetch: {
+          url: field.data('source'),
+          filter: function(data) {
+            return data.results;
+          }
+        },
+        limit: 10
+      });
     });
 
-    $('body').on(
-      'focus.typeahead.data-api',
-      '[data-provide="typeahead-url"]',
-      function (e) {
-        var $this = $(this)
-        if ($this.data('typeahead')) return
-        e.preventDefault()
-        var data_url = $this.data('source')
-        var options = {
-          source: function(query) {
-            var typeahead = this
-            $.ajax({
-              type: 'GET',
-              url: data_url,
-              data: $.param({
-                q: query
-              })
-            }).done(function(data) {
-              typeahead.process(data.results)
-            })
-          }
-        }
-        var data = $.extend({}, $this.data(), options)
-        $this.typeahead(data)
-      }
-    );
-
+    // ---------------------------------------------------------------
 
   });
 

--- a/invenio/modules/search/templates/search/index.html
+++ b/invenio/modules/search/templates/search/index.html
@@ -49,6 +49,8 @@
 }
 .websearch .nav > li > a {
   white-space: nowrap;
+  padding-left: 0px;
+  padding-right: 0px;
 }
 .websearch .nav > li > a:hover {
   background-color: inherit;
@@ -90,20 +92,26 @@
   border: 1px solid #999;
 }
 
+.form-horizontal .form-group {
+  display: block;
+  margin-bottom: 15px;
+  vertical-align: middle;
+}
+
 </style>
 
 {{ search_form(collection) }}
 
 <div class="row websearch clearfix"><!-- row 2 -->
-  {{ portalbox_sidebar(portalboxes.lt, class="span2") }}
+  {{ portalbox_sidebar(portalboxes.lt, class="col-md-2") }}
 
   {% if collection.collection_children_r %}
-    <div class="span{{ '4' if collection.collection_children_v else '8' }} collection clearfix">
+    <div class="col-md-{{ '4' if collection.collection_children_v else '8' }} collection clearfix">
       <h4>{{ _("Narrow by collection:") }}</h4>
       {{ collection_tree(collection.collection_children_r, limit=2, class="nav nav-list clearfix") }}
     </div>
   {% else %}
-      <div class="span{{ '4' if collection.collection_children_v else '8' }}">
+      <div class="col-md-{{ '4' if collection.collection_children_v else '8' }}">
       {% if collection.is_restricted %}
         <strong>{{ _('This collection is restricted. If you are authorized to access it, please click on the Search button.') }}</strong>
       {% else %}
@@ -113,16 +121,16 @@
         </div>
         {%- set of = request.values.get('of', 'hb') -%}
         {% for recid in collection.reclist[-10:]|reverse %}
-        <div class="row-fluid">
-          <div class="span12">
-            {{ format_record(recid, of, ln=g.ln)|safe }}
+        <div class="row">
+          <div class="col-md-12">
+            {{ format_record(recid, of, ln=g.ln, brief_links=False)|safe }}
             {{ '<hr/>'|safe if not loop.last }}
           </div>
         </div>
         {% endfor %}
         {% if collection.reclist|length > 10 %}
           <a href="{{ url_for('search.search', cc=collection.name, ln=g.ln, jrec=11)|safe }}"
-             class="pull-right muted">[&gt;&gt; {{ _('more')}}]</a>
+             class="pull-right text-muted">[&gt;&gt; {{ _('more')}}]</a>
         {% endif %}
         {% endif %}
       {% endif %}
@@ -130,22 +138,22 @@
   {% endif %}
 
   {% if collection.collection_children_v %}
-    <div class="span4 collection clearfix">
+    <div class="col-md-4 collection clearfix">
       <h4>{{ _("Focus on:") }}</h4>
       {{ collection_tree(collection.collection_children_v, limit=2, class="nav nav-list clearfix") }}
 
       {{ search_also(collection.externalcollections_2) }}
     </div>
   {% elif collection.externalcollections_2 %}
-      <div class="span2">
+      <div class="col-md-2">
         {{ search_also(collection.externalcollections_2) }}
       </div>
   {% endif %}
 
   {% if collection.externalcollections_2 %}
-    {{ portalbox_sidebar(portalboxes.rt, class="span2") }}
+    {{ portalbox_sidebar(portalboxes.rt, class="col-md-2") }}
   {% else %}
-    {{ portalbox_sidebar(portalboxes.rt, class="offset2 span2") }}
+    {{ portalbox_sidebar(portalboxes.rt, class="col-md-offset-1 col-md-3") }}
   {% endif %}
 
 </div>

--- a/invenio/modules/search/templates/search/results.html
+++ b/invenio/modules/search/templates/search/results.html
@@ -65,20 +65,20 @@
         <span class="btn-group">
           <span onclick="$('[name=recid]').prop('checked', function() {return !$(this).prop('checked')});"
                 class="btn">
-            <i class="icon icon-check"
+            <i class="glyphicon glyphicon-check"
                rel="tooltip"
                title="{{ _('Toggle all') }}"></i>
           </span>
           {% if current_user.precached_usebaskets %}
           <button name="action" value="addtobasket" class="btn">
-            <i class="icon icon-bookmark"
+            <i class="glyphicon glyphicon-bookmark"
                rel="tooltip"
                title="{{ _('Add to basket') }}"></i>
             <span style="display: none">{{ _('Add to basket') }}</span>
           </button>
           {% endif %}
         </span>
-        <p class="help-inline hidden-phone">
+        <p class="help-inline hidden-xs">
           {%- set r_from = (pagination.page-1)*pagination.per_page+1 -%}
           {%- set r_to = pagination.page*pagination.per_page -%}
           {%- set r_of = recids|length -%}
@@ -88,7 +88,7 @@
         <div class="btn-group pull-right">
 
           <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-            <i class="icon-random"></i> {{ _('Sort by') }}
+            <i class="glyphicon glyphicon-random"></i> {{ _('Sort by') }}
             <span class="caret"></span>
           </a>
 
@@ -114,7 +114,7 @@
             <li>
             <a href="{{ url_for('search.search', **used_args) }}{{ '#'+request.form.get('filter','')|default('', true) }}"
                class="{{ 'active' if active }}">
-              <i class="pull-right icon {{ ' icon-ok' if active }}"></i>
+              <i class="pull-right icon {{ ' glyphicon glyphicon-ok' if active }}"></i>
                 {{ _(k) }}
             </a>
             </li>
@@ -134,7 +134,7 @@
 
         <div class="btn-group pull-right" style="margin-right: 5px;">
           <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-            <i class="icon-th"></i> {{ _('Display') }}
+            <i class="glyphicon glyphicon-th"></i> {{ _('Display') }}
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
@@ -144,7 +144,7 @@
             <li><a
                href="{{ url_for('search.search', **used_args) }}{{ '#'+request.form.get('filter','')|default('', true) }}"
                class="{{ ' active' if active }}">
-              <i class="pull-right icon {{ ' icon-ok' if of==i.code }}"></i>
+              <i class="pull-right icon {{ ' glyphicon glyphicon-ok' if of==i.code }}"></i>
               {{ i.name }}
             </a></li>
           {%- endfor -%}
@@ -157,15 +157,15 @@
 
         {%- for recid in recids[(pagination.page-1)*rg:pagination.page*rg] -%}
           {%- if of[0] == 'h' -%}
-            <div class="row-fluid">
-              <div class="span1">
+            <div class="row">
+              <div class="col-md-1">
                 <label class="checkbox">
                   <input name="recid" type="checkbox" value="{{ recid }}" />
                   <abbr class="unapi-id" title="{{ recid }}"></abbr>
                   {{ loop.index+(pagination.page-1)*rg }}
                 </label>
               </div>
-              <div class="span10">
+              <div class="col-md-10">
                 {{ format_record(recid, of, ln=g.ln, qid=qid)|safe }}
                 {{ '<hr/>'|safe if not loop.last }}
               </div>
@@ -176,31 +176,31 @@
         {%- endfor -%}
         <hr/>
         <div class="row clearfix">
-          <div class="span10">
+          <div class="col-md-10">
             <span class="pull-left btn-group clearfix">
             <span onclick="$('[name=recid]').prop('checked', function() {return !$(this).prop('checked')});"
                   class="btn">
-              <i class="icon icon-check"
+              <i class="glyphicon glyphicon-check"
                  rel="tooltip"
                  title="{{ _('Toggle all') }}"></i>
             </span>
             {% if current_user.precached_usebaskets %}
             <button name="action" value="addtobasket" class="btn">
-              <i class="icon icon-bookmark"
+              <i class="glyphicon glyphicon-bookmark"
                  rel="tooltip"
                  title="{{ _('Add to basket') }}"></i>
                  <span style="display: none">{{ _('Add to basket') }}</span>
             </button>
             {% endif %}
            </span>
-            <span class="span4">
-              <select name="of" class="span2">
+            <span class="col-md-4">
+              <select name="of" class="col-md-2">
               {%- for i in export_formats -%}
                 <option value="{{ i.code }}"{{ ' selected' if request.args.get('of','hb')==i.code }}>{{ i.name }}</option>
               {%- endfor -%}
               </select>
              <button name="action" value="export" class="btn">
-              <i class="icon icon-download-alt"
+              <i class="glyphicon glyphicon-download-alt"
                  rel="tooltip"
                  title="{{ _('Export') }}"></i> {{ _('Export') }}
              </button>

--- a/invenio/modules/search/templates/search/search.html
+++ b/invenio/modules/search/templates/search/search.html
@@ -62,11 +62,11 @@
   background-color: rgba(255,255,255,0.5);
 }
 
-#facet_list .accordion-heading {
+#facet_list .panel-heading {
   background-color: whiteSmoke;
 }
 
-#facet_list .accordion-heading a:after {
+#facet_list .panel-heading a:after {
   content: ' ';
   float: right;
   display: inline-block;
@@ -81,7 +81,7 @@
   background-position: -264px -24px;
 }
 
-#facet_list ul.unstyled ul.unstyled {
+#facet_list ul.list-unstyled ul.list-unstyled {
   padding-left: 10px;
   font-size: 90%;
 }
@@ -112,7 +112,7 @@ body {
 {% if not recids|length %}
 
 <div class="row">
-  <div class="span12">
+  <div class="col-md-12">
     <p>
       <strong>{{ _('Your search did not match any records. Please try again.') }}</strong>
     </p>
@@ -123,26 +123,26 @@ body {
 {% else %}
 
 <div class="row">
-  <div class="span2 visible-desktop">
+  <div class="col-md-2 visible-md">
     <div class="row">
     <div
-      class="accordion span2 facet"
+      class="accordion col-md-2 facet"
       id="facet_list">
     </div>
     </div>
   </div>
 
-  <div class="span10">
+  <div class="col-md-10">
 
-    <div class="row visible-desktop">
-      <div class="span10">
+    <div class="row visible-md">
+      <div class="col-md-10">
         <div class="well" id="facet_filter" style="clear:both; display: none;">
           <input type="hidden" value="{{ request.args.get('p', '') }}" name="p" />
         </div>
       </div>
     </div>
     <div class="row">
-      <div id="search_results" class="span10">
+      <div id="search_results" class="col-md-10">
       {% block search_results %}
         {{ render_search_results(recids, collection, pagination, format_record) }}
       {% endblock search_results %}
@@ -193,7 +193,7 @@ body {
 
   $('#facet_list').facet({
     button_builder: function(title) {
-      return '<a style="cursor:pointer" class="muted"><small>'+title+' ...</small></a> ';
+      return '<a style="cursor:pointer" class="text-muted"><small>'+title+' ...</small></a> ';
     },
     row_builder: function(data, name) {
       var title = data[(data.length==3)?2:0],
@@ -206,7 +206,7 @@ body {
                     'data-facet-key="' + name + '" '+
                     'data-facet-value="' + data[0] + '">' +
         title +
-        '</a> <small class="muted">('+counter+')</small>' +
+        '</a> <small class="text-muted">('+counter+')</small>' +
         '</li>'
     },
     box_builder: function(name, title) {
@@ -216,7 +216,7 @@ body {
          'data-target="#facet_list" ' +
          'data-facet-key="'+ name +'"><strong>'+
         title + '</strong></a>' +
-        '<ul class="context unstyled"><ul></div>'
+        '<ul class="context list-unstyled"><ul></div>'
     },
     facets: {{ facets|tojson|safe }}
   }).on('updated', function(event) {
@@ -286,7 +286,7 @@ body {
 
       var $e = $(this),
           filterContent = function() {
-            return '{{ _('Default action is <em class="text-info">limit</em>, however you can also <abbr title="you can use shift+left click"><em class="text-error">exclude</em></abbr> selected term from results.')|safe }}<br/><a class="btn btn-small btn-error" style="cursor:pointer" ' +
+            return '{{ _('Default action is <em class="text-info">limit</em>, however you can also <abbr title="you can use shift+left click"><em class="text-danger">exclude</em></abbr> selected term from results.')|safe }}<br/><a class="btn btn-sm btn-error" style="cursor:pointer" ' +
               'data-target="#facet_list" ' +
               'data-facet="toggle" ' +
               'data-facet-action="-" '+
@@ -331,7 +331,7 @@ body {
             })
 
             if ($el_clicked.hasClass('text-info') ||
-                $el_clicked.hasClass('text-error')) {
+                $el_clicked.hasClass('text-danger')) {
               $ul.remove()
               $el_clicked.addClass('expandable')
               $('#facet_list').data('facet').filter = $('#facet_list').data('facet').exclude('!', $(this).attr('data-facet-key'), $(this).attr('data-facet-value'))
@@ -347,7 +347,7 @@ body {
       $(this).on('click', function() {
         $('[data-facet-key="'+ $(this).attr('data-facet-key') +'"]')
           .attr('data-facet-action', '+')
-          .removeClass('text-error')
+          .removeClass('text-danger')
           .removeClass('text-info')
           .css('font-weight', 'normal')
         $(this).removeClass('muted').addClass('text-info')
@@ -373,7 +373,7 @@ body {
       .filter('[data-facet-value="'+event.value+'"]')
       .each(function(e) {
         $(this)
-          .removeClass('text-error')
+          .removeClass('text-danger')
           .removeClass('text-info')
           .css('font-weight', 'normal')
           .attr('data-facet-action', '+')
@@ -429,7 +429,7 @@ body {
             var facet = {url: options.url_map[event.key]
                       , facet: event.key}
               , data = {parent: event.value}
-              , $ul = $('<ul class="context unstyled"><ul>').clone().appendTo($el_clicked.parent())
+              , $ul = $('<ul class="context list-unstyled"><ul>').clone().appendTo($el_clicked.parent())
 
             var data_facet = $('#facet_list').data('facet')
             if (data_facet.find('!', event.key, event.value).length == 0) {

--- a/invenio/modules/tags/static/js/tags/record_editor.js
+++ b/invenio/modules/tags/static/js/tags/record_editor.js
@@ -234,7 +234,7 @@ WebTagEditor.prototype.onServerError = function(item, intended_action, arguments
 
             for(var i = 0; i < messages.length; i++)
             {
-                this.$errorArea.html('<div class="alert alert-error"><strong>Error:</strong> '+messages[i]+'</div>');
+                this.$errorArea.html('<div class="alert alert-danger"><strong>Error:</strong> '+messages[i]+'</div>');
             }
        }
     }
@@ -300,7 +300,7 @@ WebTagEditor.prototype.tokenInput_tokenFormatter = function(item) {
 
     if(item.status == 'removing')
     {
-        token_html += ' <p class="text-right text-error">&nbsp;(removing)</p>';
+        token_html += ' <p class="text-right text-danger">&nbsp;(removing)</p>';
     }
     else if(item.status == 'adding')
     {

--- a/invenio/modules/tags/templates/tags/display_base.html
+++ b/invenio/modules/tags/templates/tags/display_base.html
@@ -24,7 +24,7 @@
 {% block body %}
   <div class="btn-group pull-right">
     <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-      <i class="icon-th"></i>
+      <i class="glyphicon glyphicon-th"></i>
       {{_('Display mode')}}
       <span class="caret"></span>
     </a>
@@ -32,7 +32,7 @@
       <li>
         <a href="{{ url_for('.display_cloud') }}">
           {% if display_mode == 'cloud' %}
-            <i class="pull-right icon icon-ok"></i>
+            <i class="pull-right icon glyphicon glyphicon-ok"></i>
           {% endif %}
           {{_('Cloud')}}
         </a>
@@ -40,7 +40,7 @@
       <li>
         <a href="{{ url_for('.display_list') }}">
           {% if display_mode == 'list' %}
-            <i class="pull-right icon icon-ok"></i>
+            <i class="pull-right icon glyphicon glyphicon-ok"></i>
           {% endif %}
           {{_('List')}}
         </a>

--- a/invenio/modules/tags/templates/tags/display_cloud_base.html
+++ b/invenio/modules/tags/templates/tags/display_cloud_base.html
@@ -20,9 +20,9 @@
 {% extends "tags/display.html" %}
 
 {% block webtag_display %}
-<div class="row-fluid">
+<div class="row">
   <h4> {{_('Tag Cloud') }} </h4>
-  <div class="span4">
+  <div class="col-md-4">
   {% for tag in user_tags %}
       <a href="{{ url_for('search.search', p='tag:"' + tag['name']) + '"' }}"
       {#<a href="{{ url_for('webtag.tag_edit', id_tag=tag.id) }}"#}

--- a/invenio/modules/tags/templates/tags/display_list_base.html
+++ b/invenio/modules/tags/templates/tags/display_list_base.html
@@ -22,10 +22,10 @@
 {% from "_formhelpers.html" import render_filter_form with context %}
 
 {% block webtag_display %}
-<div class="row-fluid">
+<div class="row">
 <h4> {{_('Tag list') }} </h4>
-<div class="row-fluid">
-  <div class="span6">
+<div class="row">
+  <div class="col-md-6">
     <form name="webtag_delete" action="{{ url_for('.delete') }}" method="post">
     <table class="table table-striped table-bordered table-condensed">
       <thead class="mailboxheader">

--- a/invenio/modules/tags/templates/tags/record_tags_base.html
+++ b/invenio/modules/tags/templates/tags/record_tags_base.html
@@ -22,7 +22,7 @@
 {# {% set record = get_record(id_bibrec) %} #}
 
 {% block webtag_list %}
-  <i class="icon-tags"></i>
+  <i class="glyphicon glyphicon-tags"></i>
   {% if tag_infos %}
     {% for tag in tag_infos %}
 

--- a/invenio/modules/tags/templates/tags/tag_popover_content_base.html
+++ b/invenio/modules/tags/templates/tags/tag_popover_content_base.html
@@ -39,7 +39,7 @@
 	 jeditable-post-property-value="annotation_value"
 	 id="webtag_annotation_{{id_bibrec}}_{{tag.id}}">{{ tag.annotation or _('No annotation') }}</p>
 
-	<p class="muted">({{ _('Click to edit annotation') }})</p>
+	<p class="text-muted">({{ _('Click to edit annotation') }})</p>
 	<hr/>
 	<p style="text-align: right;">
 		<a href='#' data-dismiss="popover" class="btn btn-success">

--- a/invenio/modules/workflows/templates/workflows/entry_details.html
+++ b/invenio/modules/workflows/templates/workflows/entry_details.html
@@ -19,63 +19,63 @@
         <h3 id="myModalLabel">{{ entry.id }}</h3>
 </div>
 <div class="modal-body">
-    <div class="row-fluid">
-        <div class="span12">
+    <div class="row">
+        <div class="col-md-12">
                         Owner: <b>{{ entry.id_user }}</b> | Creation date: <b>{{ entry.created }}</b>
         </div>
     </div>
-    <div class="row-fluid">
-         <div class="span5">
+    <div class="row">
+         <div class="col-md-5">
             Preview:
             <div class="well">
-                <div class="btn-group" name="object_preview_btn" data-toggle="buttons-radio">
-                    <button class="btn btn-mini btn-primary active" name="hd">HTML</button>
-                    <button class="btn btn-mini btn-primary" name="marcxml">MARCXML</button>
-                    <button class="btn btn-mini btn-primary" name="xm">MARC</button>
+                <div class="btn-group" name="object_preview_btn" data-toggle="buttons">
+                    <button class="btn btn-xs btn-primary active" name="hd">HTML</button>
+                    <button class="btn btn-xs btn-primary" name="marcxml">MARCXML</button>
+                    <button class="btn btn-xs btn-primary" name="xm">MARC</button>
                 </div>
                 <div class="btn-group pull-right">
-                    <button class="btn btn-mini">Show PDF</button>
-                    <button class="btn btn-mini">Show log</button>
+                    <button class="btn btn-xs">Show PDF</button>
+                    <button class="btn btn-xs">Show log</button>
                 </div>
                 <div name="object_preview">{{- data_preview|safe -}}</div>
              </div>
          </div>
-         <div class="span3">
+         <div class="col-md-3">
             Workflow definition:
             <div class="well">
                 {{ utils.function_display(workflow_func, entry.get_extra_data()['task_counter']) }}
             </div>
          </div>
-         <div class="span4">
+         <div class="col-md-4">
             Messages:
             <div class="well">
                 <h4>Matching is finished. Confirm match!</h4>
                 <p>There are 3 possible matches.</p>
-                <a href="#" class="btn">Resolve match <i class="icon-zoom-in"></i></a>
+                <a href="#" class="btn">Resolve match <i class="glyphicon glyphicon-zoom-in"></i></a>
             </div>
          </div>
     </div>
-    <div class="row-fluid">
-        <div class="span12">
+    <div class="row">
+        <div class="col-md-12">
             Keywords:
             <form>
                 <textarea id="entry_keywords" placeholder="Your keywords here...">ELECTRON POSITRON: COLLIDING BEAMS | COLLIDING BEAMS: ELECTRON POSITRON | ELECTRON POSITRON: ANNIHILATION | ANNIHILATION: ELECTRON POSITRON | JET: HADROPRODUCTION | HADROPRODUCTION: JET | HADRON: MULTIPLE PRODUCTION | MULTIPLE PRODUCTION: HADRON | QUARK: JET | charm | bottom | LEPTON: DIRECT PRODUCTION | DIRECT PRODUCTION: LEPTON | QUARK: SEMILEPTONIC DECAY | SEMILEPTONIC DECAY: QUARK | QUARK: NONLEPTONIC DECAY | NONLEPTONIC DECAY: QUARK | CHARGED PARTICLE: MULTIPLICITY | MARK II | EXPERIMENTAL RESULTS | SLAC PEP STOR | 29 GEV-CMS</textarea>
             </form>
         </div>
     </div>
-    <div class="row-fluid">
-        <div class="span12">
+    <div class="row">
+        <div class="col-md-12">
             Log:
             <pre>{{ log }}</pre>
         </div>
     </div>
 </div>
 <div class="modal-footer">
-    <a class="btn btn-primary" href="{{ url_for('holdingpen.details', bwobject_id=entry.id)}}" >Open in HoldingPen <i class="icon-white icon-wrench"></i></a>
-    <button class="btn btn-success">Apply <i class="icon-ok icon-white"></i></button>
+    <a class="btn btn-primary" href="{{ url_for('holdingpen.details', bwobject_id=entry.id)}}" >Open in HoldingPen <i class="glyphicon glyphicon-wrench"></i></a>
+    <button class="btn btn-success">Apply <i class="glyphicon glyphicon-ok"></i></button>
     <button class="btn btn-danger">Delete <i class="icon-remove icon-white"></i></button>
-    <button class="btn">Edit <i class="icon-edit"></i></button>
-    <button id="extra" class="btn">Assign ticket <i class="icon-flag"></i></button>
+    <button class="btn">Edit <i class="glyphicon glyphicon-edit"></i></button>
+    <button id="extra" class="btn">Assign ticket <i class="glyphicon glyphicon-flag"></i></button>
     <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
 </div>
 {% endblock %}

--- a/invenio/modules/workflows/templates/workflows/hp_approval_widget.html
+++ b/invenio/modules/workflows/templates/workflows/hp_approval_widget.html
@@ -24,11 +24,11 @@
 
 {% block hpbody %}
     <div class"row-fluid">
-        <div class="span3 pull-left"><a href="{{url_for('holdingpen.maintable')}}"><i class="icon-hand-left"></i> Back to Main Table</a></div>
+        <div class="col-md-3 pull-left"><a href="{{url_for('holdingpen.maintable')}}"><i class="icon-hand-left"></i> Back to Main Table</a></div>
         <div class="span4"><h1>Approval Widget</h1></div>
     </div>
 
-    <div class="container-fluid">
+    <div class="container">
         <div id="goodbye-msg" class="span12 text-center">
         </div>
         {% for i in range(obj_number) %}
@@ -39,31 +39,31 @@
         {% set workflow_func = workflow_func_list[i] %}
         {% set info = info_list[i] %}
         {% set log = logtext_list[i] %}
-            <div id="row_fluid{{i}}" class="row-fluid">
-                <div class="span9">
+            <div id="row_fluid{{i}}" class="row">
+                <div class="col-md-9">
                     <div class="btn-group" name="object_preview_btn" data-toggle="buttons-radio">
-                        <button class="btn btn-mini btn-primary active" name="hd" onclick="setDataPreview('hd', {{bwobject.id}})">HTML</button>
-                        <button class="btn btn-mini btn-primary" name="marcxml" onclick="setDataPreview('xm', {{bwobject.id}})">MARCXML</button>
-                        <button class="btn btn-mini btn-primary" name="xm" onclick="setDataPreview('tm', {{bwobject.id}})">MARC</button>
+                        <button class="btn btn-xs btn-primary active" name="hd" onclick="setDataPreview('hd', {{bwobject.id}})">HTML</button>
+                        <button class="btn btn-xs btn-primary" name="marcxml" onclick="setDataPreview('xm', {{bwobject.id}})">MARCXML</button>
+                        <button class="btn btn-xs btn-primary" name="xm" onclick="setDataPreview('tm', {{bwobject.id}})">MARC</button>
                     </div>
-                    <div class="btn-group pull" name="data_version" data-toggle="buttons-radio">
-                        <button class="btn btn-mini active" name="initial" onclick="setbwoid({{bwparent.id}})">Initial</button>
+                    <div class="btn-group pull" name="data_version" data-toggle="buttons">
+                        <button type="radio" class="btn btn-xs active" name="initial" onclick="setbwoid({{bwparent.id}})">Initial</button>
                         {% if bwobject.version == 1 %}
-                            <button class="btn btn-mini" name="error" onclick="setbwoid({{bwobject.id}})">Error</button>
+                            <button type="radio" class="btn btn-xs" name="error" onclick="setbwoid({{bwobject.id}})">Error</button>
                         {% else %}
-                            <button class="btn btn-mini disabled" name="error">Error</button>
+                            <button type="radio" class="btn btn-xs disabled" name="error">Error</button>
                         {% endif %}
                         {% if bwobject.version == 2 %}
-                            <button class="btn btn-mini" name="final" onclick="setbwoid({{bwobject.id}})">Final</button>
+                            <button type="radio" class="btn btn-xs" name="final" onclick="setbwoid({{bwobject.id}})">Final</button>
                         {% else %}
-                            <button class="btn btn-mini disabled" name="final">Final</button>
+                            <button type="radio" class="btn btn-xs disabled" name="final">Final</button>
                         {% endif %}
                     </div>
                     <div id="object_preview_container{{bwobject.id}}" class="object_preview_container">
                         {{ data_preview|safe }}
                     </div>
                 </div>
-                <div class="span3">
+                <div class="col-md-3">
                     <div class="details_link">
                         <a href="/admin/holdingpen/details?bwobject_id={{bwobject.id}}"><button class="btn btn-primary" type="button"><i class="icon-eye-open icon-white"></i> Record Details</button></a>
                     </div>
@@ -122,7 +122,7 @@
                     </div>
                 </div>
             </div>
-            <div id="decision-btns{{i}}" class="row-fluid decision-btns">
+            <div id="decision-btns{{i}}" class="row decision-btns">
                 <form id="form{{i}}" class="theform" method="POST" name="{{ url_for('holdingpen.resolve_widget', bwobject_id=bwobject.id, widget='approval_widget') }}">
                     {% for field in widget %}
                         {{ field }}

--- a/invenio/modules/workflows/templates/workflows/hp_bibmatch_widget.html
+++ b/invenio/modules/workflows/templates/workflows/hp_bibmatch_widget.html
@@ -16,19 +16,19 @@
     <h1>Bibmatch Widget</h1>
 
     <div class="container">
-        <div class="row-fluid">
-            <div class="span12">
-                <div class="row-fluid">
-                    <div class="span6">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="row">
+                    <div class="col-md-6">
                         <div id="record_preview_container">
                             Submitted Record
-                            <pre id="record_preview" name="object_preview" class="prettyprint span12">
+                            <pre id="record_preview" name="object_preview" class="prettyprint col-md-12">
                                 {{ data_preview }}
                             </pre>
                         </div>
                     </div>
 
-                    <div class="span6">
+                    <div class="col-md-6">
                         {% set i = 0 %}
                         {% for match in match_preview %}
                         {% if match %}

--- a/invenio/modules/workflows/templates/workflows/hp_details.html
+++ b/invenio/modules/workflows/templates/workflows/hp_details.html
@@ -35,31 +35,31 @@
 
 {% block hpbody %}
     <div class="row-fluid">
-        <div class="span3 pull-left"><a href="{{url_for('holdingpen.maintable')}}"><i class="icon-hand-left"></i> Back to Main Table</a></div>
+        <div class="col-md-3 pull-left"><a href="{{url_for('holdingpen.maintable')}}"><i class="icon-hand-left"></i> Back to Main Table</a></div>
         <div class="span4"><h1>Record Details</h1></div>
     </div>
 
     <div id = "alert_placeholder"></div>
 
-    <div class="container-fluid">
-        <div class="row-fluid">
-            <div class="span9">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-9">
                 <div class="btn-group" name="object_preview_btn" data-toggle="buttons-radio">
-                    <button class="preview btn btn-mini btn-primary active" name="hd">HTML</button>
-                    <button class="preview btn btn-mini btn-primary" name="xm">MARCXML</button>
-                    <button class="preview btn btn-mini btn-primary" name="tm">MARC</button>
+                    <button type="radio" class="preview btn btn-xs btn-primary active" name="hd">HTML</button>
+                    <button type="radio" class="preview btn btn-xs btn-primary" name="xm">MARCXML</button>
+                    <button type="radio" class="preview btn btn-xs btn-primary" name="tm">MARC</button>
                 </div>
-                <div class="btn-group pull" name="data_version" data-toggle="buttons-radio">
-                    <button class="btn btn-mini active" name="initial" onclick="">Initial</button>
+                <div class="btn-group pull" name="data_version" data-toggle="buttons">
+                    <button type="radio" class="btn btn-xs active" name="initial" onclick="">Initial</button>
                     {% if bwobject.version == 1 %}
-                        <button class="btn btn-mini" name="final" onclick="">Final</button>
+                        <button type="radio" class="btn btn-xs" name="final" onclick="">Final</button>
                     {% else %}
-                        <button class="btn btn-mini disabled" name="final">Final</button>
+                        <button class="btn btn-xs disabled" name="final">Final</button>                 
                     {% endif %}
                     {% if bwobject.version == 2 %}
-                        <button class="btn btn-mini" name="error" onclick="">Error</button>
+                        <button class="btn btn-xs" name="error" onclick="">Error</button>
                     {% else %}
-                        <button class="btn btn-mini disabled" name="error">Error</button>
+                        <button class="btn btn-xs disabled" name="error">Error</button>
                     {% endif %}
                 </div>
 
@@ -82,25 +82,25 @@
                     {{ data_preview|safe }}
                 </div>
             </div>
-
-            <div class="span3">
+            
+            <div class="col-md-3">
                 <div id="action-area" class="alert">
                     <b>Actions</b>
-                    <div class="row-fluid">
-                        <div class="span6">
+                    <div class="row">
+                        <div class="col-md-6">
                             {% if bwobject.get_extra_data()['widget'] %}
-                            <a class="btn btn-info btn-small" href="{{ url_for('holdingpen.show_widget', bwobject_id=bwobject.id, widget=info['widget']) }}" ><i class="icon-wrenchwhite icon-wrench"></i>Widget</a></br>
+                            <a class="btn btn-info btn-sm" href="{{ url_for('holdingpen.show_widget', bwobject_id=bwobject.id, widget=info['widget']) }}" ><i class="icon-wrenchwhite icon-wrench"></i>Widget</a></br>
                             {% else %}
-                            <a class="btn btn-info btn-small disabled"><i class="icon-wrenchwhite icon-wrench"></i>Widget</a></br>
+                            <a class="btn btn-info btn-sm disabled"><i class="glyphicon glyphicon-wrench"></i>Widget</a></br>
                             {% endif %}
 
                         </div>
 
-                        <div id="static-actions" class="span6">
-                            <button id="restart_button" class="btn btn-small btn-primary btn-block" rel="popover" name="{{ bwobject.id }}"/><i class="icon-repeat"></i>Restart</button></br>
-                            <button id="restart_button_prev" class="btn btn-small btn-block" rel="popover" name="{{ bwobject.id }}"/><i class="icon-step-backward"></i>Restart Task</button></br>
-                            <button id="continue_button" class="btn btn-small btn-block" rel="popover" name="{{ bwobject.id }}"/><i class="icon-step-forward"></i>Skip Task</button></br>
-                            <a id="delete_btn" href="#confirmationModal" role="button" class="btn btn-small btn-block btn-danger" data-toggle="modal"><i class="icon-trash"></i>Delete</a>
+                        <div id="static-actions" class="col-md-6">
+                            <button id="restart_button" class="btn btn-sm btn-primary btn-block" rel="popover" name="{{ bwobject.id }}"/><i class="glyphicon glyphicon-repeat"></i>Restart</button></br>
+                            <button id="restart_button_prev" class="btn btn-sm btn-block" rel="popover" name="{{ bwobject.id }}"/><i class="glyphicon glyphicon-step-backward"></i>Restart Task</button></br>
+                            <button id="continue_button" class="btn btn-sm btn-block" rel="popover" name="{{ bwobject.id }}"/><i class="glyphicon glyphicon-step-forward"></i>Skip Task</button></br>
+                            <a id="delete_btn" href="#confirmationModal" role="button" class="btn btn-sm btn-block btn-danger" data-toggle="modal"><i class="glyphicon glyphicon-trash"></i>Delete</a>
 
                             <div id="confirmationModal" class="modal hide fade" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                               <div class="modal-header">

--- a/invenio/modules/workflows/templates/workflows/hp_index.html
+++ b/invenio/modules/workflows/templates/workflows/hp_index.html
@@ -3,21 +3,63 @@
 
 	<h1>HoldingPen Overview</h1>
 		<div class="container">
-			<div class="span3">
+			<div class="col-md-3">
 				<h4>Main Table</h4>
 				<div><a href="{{url_for('holdingpen.maintable')}}"><button class="btn btn-primary" type="button">Show Table</button></a></div>
 			</div>
-			<div class="span3">
+			<div class="col-md-3">
 				<h4>Pending Tasks</h4>
 				{% for task in tasks.iterkeys() %}
 					<div class="task-btns"><a href="{{url_for('holdingpen.maintable')}}"><button class="btn btn-warning" type="button">{{task}}: {{tasks[task][0]}}</button></a></br></div>
 				{% endfor %}
 			</div>
-			<div class="span3">
+			<div class="col-md-3">
 				<h4>Assigned to me</h4>
 				<div><a href="{{url_for('holdingpen.maintable')}}"><button class="btn btn-primary" type="button">Show Records</button></a></div>
 			</div>
 		</div>
 		
 
+    <style type="text/css" title="currentStyle">
+      @import "{{ url_for('workflows.static', filename='css/workflows/DT_bootstrap.css') }}";
+    </style>
+
+    <h1>Records in Holding Pen</h1>
+
+    <button id="refresh_button" class="btn btn-primary pull-right">Refresh!</button>
+
+    <div class="container">
+        <div class="row">
+            <table id="example" cellpadding="0" cellspacing="0" border="0" class="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>Id</th>
+                        <th>Title</th>
+                        <th>Source</th>
+                        <th>Category</th>
+                        <th>Workflow ID</th>
+                        <th>Owner</th>
+                        <th>Created</th>
+                        <th>Version</th>
+                        <th>Details</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
 {% endblock %}

--- a/invenio/modules/workflows/templates/workflows/hp_maintable.html
+++ b/invenio/modules/workflows/templates/workflows/hp_maintable.html
@@ -39,7 +39,7 @@
     <h1>Records in Holding Pen</h1>
 
     <div class="row">
-        <div class="span6 pull-left">
+        <div class="col-md-6 pull-left">
             <ul class="nav nav-pills">
                 <li class="active">
                     <a href="#">Home</a>
@@ -62,7 +62,7 @@
                 </li>
             </ul>
         </div>
-        <div id="multi-approval" class="span3 pull-left">
+        <div id="multi-approval" class="col-md-3 pull-left">
         </div>
         <div class="span1 pull-right">
             <button id="refresh_button" class="btn btn-primary">Refresh!</button>

--- a/invenio/modules/workflows/templates/workflows/layout.html
+++ b/invenio/modules/workflows/templates/workflows/layout.html
@@ -1,8 +1,8 @@
 {% css url_for('workflows.static', filename='css/workflows/style.css'), '20-workflows' %}
 {% extends "page.html" %}
 {% block body %}
-    <div class="row-fluid">
-        <div class="span2">
+    <div class="row">
+        <div class="col-md-2">
             <div class="well sidebar-nav">
                 <ul class="nav nav-list">
                     <li><a href="{{ url_for('workflows.index') }}"
@@ -21,7 +21,7 @@
                 </ul>
             </div>
         </div>
-        <div class="span10">
+        <div class="col-md-10">
             {% block workflowbody %}{% endblock %}
         </div>
     <div id="myModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/invenio/modules/workflows/templates/workflows/workflow_details.html
+++ b/invenio/modules/workflows/templates/workflows/workflow_details.html
@@ -6,13 +6,13 @@
         <h3 id="myModalLabel">{{ workflow_metadata.name }}</h3>
 </div>
 <div class="modal-body">
-    <div class="row-fluid">
-        <div class="span12">
+    <div class="row">
+        <div class="col-md-12">
                         Owner: <b>{{ workflow_metadata.uid }}</b> | Creation date: <b>{{ workflow_metadata.created }}</b> | Last modification date: <b>{{ workflow_metadata.modified }}</b>
         </div>
     </div>
-    <div class="row-fluid">
-        <div class="span5">
+    <div class="row">
+        <div class="col-md-5">
            Workflow definition:
            <div class="well">
                {{ utils.function_display(workflow_func, [-1]) }}
@@ -28,7 +28,7 @@
                 </div>
             </div>
         </div>
-        <div class="span7">
+        <div class="col-md-7">
            Error message
            <div class="well">
                 <div class="workflow_message">
@@ -37,7 +37,7 @@
             </div>
         </div>
     </div>
-    <div class="row-fluid">
+    <div class="row">
         Log:
         <pre>{{ log }}</pre>
     </div>
@@ -45,7 +45,7 @@
 <div class="modal-footer">
         <input type="submit" class="btn" name="{{workflow_metadata.id}}_beginning" value="Restart from BEGINNING" />
         <input type="submit" class="btn" name="{{workflow_metadata.id}}_current" value="Restart from CURRENT task" />
-        <button id="extra" class="btn">Assign ticket <i class="icon-flag"></i></button>
+        <button id="extra" class="btn">Assign ticket <i class="glyphicon glyphicon-flag"></i></button>
         <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
 </div>
 {% endblock %}

--- a/invenio/modules/workflows/views/holdingpen.py
+++ b/invenio/modules/workflows/views/holdingpen.py
@@ -31,7 +31,6 @@ from ..utils import (get_workflow_definition,
                      sort_bwolist)
 from ..api import continue_oid_delayed, start
 
-
 blueprint = Blueprint('holdingpen', __name__, url_prefix="/admin/holdingpen",
                       template_folder='../templates',
                       static_folder='../static')

--- a/invenio/utils/forms.py
+++ b/invenio/utils/forms.py
@@ -44,21 +44,34 @@ class RowWidget(object):
     """
     Renders a list of fields as a set of table rows with th/td pairs.
     """
-    def __init__(self):
-        pass
+    def __init__(self, **kwargs):
+        self.defaults = kwargs
 
-    def __call__(self, field, **kwargs):
+    def __call__(self, field, class_='', row_class='row', **kwargs):
+        """
+        There are Bootstrap 3 specific improvements for row wrapping.
+        """
         html = []
         hidden = ''
-        for subfield in field:
+        arguments = self.defaults
+        arguments.update(kwargs)
+        classes = arguments.get('classes', {})
+        for i, subfield in enumerate(field):
             if subfield.type == 'HiddenField':
                 hidden += text_type(subfield)
             else:
-                html.append('%s%s' % (hidden, text_type(subfield(class_="span1", placeholder=subfield.label.text))))
+                wrapper_class = classes.get(i, '')
+                html.append('%s<div class="%s">%s</div>' % (
+                    hidden, 
+                    wrapper_class,
+                    text_type(subfield(
+                        class_=class_,
+                        placeholder=subfield.label.text))))
                 hidden = ''
         if hidden:
             html.append(hidden)
-        return HTMLString(''.join(html))
+        return HTMLString('<div class="%s">' % (row_class, ) + 
+                          ''.join(html) + '</div>')
 
 
 class TimeField(Field):


### PR DESCRIPTION
- fast replacement - accordion, accordion-toggle deleted
- header porting completed
- searchbar migration
- fixed different padding at different window widths
- css fom page.html, header.html moved to base.css
- layout of the search page adapted
- footer stylization
- portalboxes migrated to panels
- registration, login page form migration
- icon -> glyphicon replacement
- account management page migrated
- navarheader substituted with dropdown-header in a couple of places
- search settings menu improved
- advanced search form adapted
- replaced all occurences of buttons-radio -> buttons
- searchbar and search options menu improvements
- search settings layout improved
- migration to bootstrap-typeahead
- makefile modified to install bootstrap3 and bootstrap-typeahead
- deposit form
- messages menu
- new message form
- autocompletition in deposit form
- write comment modal + add review modal
- Add To Search form converted from dropdown to collapsable
- Typeahead for search field and Add To Search form
